### PR TITLE
Add Support for Bearing Range Factor

### DIFF
--- a/include/jrl/IOMeasurements.h
+++ b/include/jrl/IOMeasurements.h
@@ -1,8 +1,9 @@
 #pragma once
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/geometry/Pose3.h>
-#include <gtsam/slam/BetweenFactor.h>
 #include <gtsam/nonlinear/PriorFactor.h>
+#include <gtsam/sam/BearingRangeFactor.h>
+#include <gtsam/slam/BetweenFactor.h>
 
 #include <nlohmann/json.hpp>
 using json = nlohmann::json;
@@ -15,6 +16,8 @@ static const std::string PriorFactorPose2Tag = "PriorFactorPose2";
 static const std::string PriorFactorPose3Tag = "PriorFactorPose3";
 static const std::string RangeFactorPose2Tag = "RangeFactorPose2";
 static const std::string RangeFactorPose3Tag = "RangeFactorPose3";
+static const std::string BearingRangeFactorPose2Tag = "BearingRangeFactorPose2";
+static const std::string BearingRangeFactorPose3Tag = "BearingRangeFactorPose3";
 static const std::string BetweenFactorPoint2Tag = "BetweenFactorPoint2";
 static const std::string BetweenFactorPoint3Tag = "BetweenFactorPoint3";
 static const std::string PriorFactorPoint2Tag = "PriorFactorPoint2";

--- a/include/jrl/IOValues.h
+++ b/include/jrl/IOValues.h
@@ -9,12 +9,16 @@
 using json = nlohmann::json;
 namespace jrl {
 
+static const std::string Rot2Tag = "Rot2";
 static const std::string Pose2Tag = "Pose2";
+static const std::string Rot3Tag = "Rot3";
 static const std::string Pose3Tag = "Pose3";
 static const std::string Point2Tag = "Point2";
 static const std::string Point3Tag = "Point3";
+static const std::string Unit3Tag = "Unit3";
 static const std::string VectorTag = "Vector";
 static const std::string ScalarTag = "Scalar";
+static const std::string BearingRangeTag = "BearingRange";
 
 namespace io_values {
 
@@ -37,12 +41,27 @@ json serialize(T obj) {  // Base Parse function for builtins. Specialization pro
   return output;
 }
 
+
+/**********************************************************************************************************************/
+// Rot2
+template <>
+gtsam::Rot2 parse<gtsam::Rot2>(json input_json);
+template <>
+json serialize<gtsam::Rot2>(gtsam::Rot2 pose);
+
 /**********************************************************************************************************************/
 // POSE2
 template <>
 gtsam::Pose2 parse<gtsam::Pose2>(json input_json);
 template <>
 json serialize<gtsam::Pose2>(gtsam::Pose2 pose);
+
+/**********************************************************************************************************************/
+// Rot2
+template <>
+gtsam::Rot3 parse<gtsam::Rot3>(json input_json);
+template <>
+json serialize<gtsam::Rot3>(gtsam::Rot3 pose);
 
 /**********************************************************************************************************************/
 // POSE3
@@ -71,6 +90,33 @@ template <>
 gtsam::Point3 parse<gtsam::Point3>(json input_json);
 template <>
 json serialize<gtsam::Point3>(gtsam::Point3 point);
+
+/**********************************************************************************************************************/
+// Unit3
+template <>
+gtsam::Unit3 parse<gtsam::Unit3>(json input_json);
+template <>
+json serialize<gtsam::Unit3>(gtsam::Unit3 point);
+
+/**********************************************************************************************************************/
+// BearingRange Need special treatment because c++ does not allow function partial specialization
+template <typename A1, typename A2, typename B = typename gtsam::Bearing<A1, A2>::result_type,
+          typename R = typename gtsam::Range<A1, A2>::result_type>
+gtsam::BearingRange<A1, A2> parseBearingRange(json input_json) {
+  B bearing = parse<B>(input_json["bearing"]);
+  R range = parse<R>(input_json["range"]);
+  return gtsam::BearingRange<A1, A2>(bearing, range);
+}
+
+template <typename A1, typename A2, typename B = typename gtsam::Bearing<A1, A2>::result_type,
+          typename R = typename gtsam::Range<A1, A2>::result_type>
+json serializeBearingRange(gtsam::BearingRange<A1, A2> bearingrange) {
+  json output;
+  output["type"] = BearingRangeTag;
+  output["bearing"] = serialize<B>(bearingrange.bearing());
+  output["range"] = serialize<R>(bearingrange.range());
+  return output;
+}
 
 }  // namespace io_values
 

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -19,12 +19,16 @@ PYBIND11_MODULE(jrl_python, m) {
   // Import gtsam to ensure that python has access to return types
   py::module gtsam = py::module::import("gtsam");
 
+  m.attr("Rot2Tag") = py::str(Rot2Tag);
   m.attr("Pose2Tag") = py::str(Pose2Tag);
+  m.attr("Rot3Tag") = py::str(Rot3Tag);
   m.attr("Pose3Tag") = py::str(Pose3Tag);
   m.attr("Point2Tag") = py::str(Point2Tag);
   m.attr("Point3Tag") = py::str(Point3Tag);
+  m.attr("Unit3Tag") = py::str(Unit3Tag);
   m.attr("VectorTag") = py::str(VectorTag);
   m.attr("ScalarTag") = py::str(ScalarTag);
+  m.attr("BearingRangeTag") = py::str(BearingRangeTag);
 
   m.attr("PriorFactorPose2Tag") = py::str(PriorFactorPose2Tag);
   m.attr("PriorFactorPose3Tag") = py::str(PriorFactorPose3Tag);
@@ -32,6 +36,8 @@ PYBIND11_MODULE(jrl_python, m) {
   m.attr("BetweenFactorPose3Tag") = py::str(BetweenFactorPose3Tag);
   m.attr("RangeFactorPose2Tag") = py::str(RangeFactorPose2Tag);
   m.attr("RangeFactorPose3Tag") = py::str(RangeFactorPose3Tag);
+  m.attr("BearingRangeFactorPose2Tag") = py::str(BearingRangeFactorPose2Tag);
+  m.attr("BearingRangeFactorPose3Tag") = py::str(BearingRangeFactorPose3Tag);
   m.attr("PriorFactorPoint2Tag") = py::str(PriorFactorPoint2Tag);
   m.attr("PriorFactorPointTag") = py::str(PriorFactorPoint3Tag);
   m.attr("BetweenFactorPoint2Tag") = py::str(BetweenFactorPoint2Tag);

--- a/src/IOValues.cpp
+++ b/src/IOValues.cpp
@@ -5,6 +5,23 @@ using json = nlohmann::json;
 
 namespace jrl {
 namespace io_values {
+
+/**********************************************************************************************************************/
+// Rot2
+template <>
+gtsam::Rot2 parse<gtsam::Rot2>(json input_json) {
+  double theta = input_json["theta"].get<double>();
+  return gtsam::Rot2(theta);
+}
+
+template <>
+json serialize<gtsam::Rot2>(gtsam::Rot2 rot) {
+  json output;
+  output["type"] = Rot2Tag;
+  output["theta"] = rot.theta();
+  return output;
+}
+
 /**********************************************************************************************************************/
 // POSE2
 template <>
@@ -22,6 +39,23 @@ json serialize<gtsam::Pose2>(gtsam::Pose2 pose) {
   output["x"] = pose.x();
   output["y"] = pose.y();
   output["theta"] = pose.theta();
+  return output;
+}
+
+/**********************************************************************************************************************/
+// Rot2
+template <>
+gtsam::Rot3 parse<gtsam::Rot3>(json input_json) {
+  std::vector<double> q = input_json["rotation"].get<std::vector<double>>();
+  return gtsam::Rot3::Quaternion(q[0], q[1], q[2], q[3]);
+}
+
+template <>
+json serialize<gtsam::Rot3>(gtsam::Rot3 rot) {
+  json output;
+  output["type"] = Rot3Tag;
+  gtsam::Vector q = rot.quaternion();
+  output["rotation"] = {q(0), q(1), q(2), q(3)};
   return output;
 }
 
@@ -100,6 +134,29 @@ json serialize<gtsam::Point3>(gtsam::Point3 point) {
   output["z"] = point.z();
   return output;
 }
+
+
+/**********************************************************************************************************************/
+// Unit3
+template <>
+gtsam::Unit3 parse<gtsam::Unit3>(json input_json) {
+  double i = input_json["i"].get<double>();
+  double j = input_json["j"].get<double>();
+  double k = input_json["k"].get<double>();
+  return gtsam::Unit3(i, j, k);
+}
+
+template <>
+json serialize<gtsam::Unit3>(gtsam::Unit3 unit) {
+  json output;
+  gtsam::Point3 p = unit.point3();
+  output["type"] = Unit3Tag;
+  output["i"] = p.x();
+  output["j"] = p.y();
+  output["k"] = p.z();
+  return output;
+}
+
 
 }  // namespace io_values
 }  // namespace jrl

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -38,16 +38,18 @@ std::map<std::string, ValueParser> Parser::loadDefaultValueAccumulators() {
 std::map<std::string, MeasurementParser> Parser::loadDefaultMeasurementParsers() {
   // clang-format off
   std::map<std::string, MeasurementParser> parser_functions = {
-      {PriorFactorPose2Tag,    [](json input) { return parsePrior<gtsam::Pose2>(&parse<gtsam::Pose2>, input); }},
-      {PriorFactorPose3Tag,    [](json input) { return parsePrior<gtsam::Pose3>(&parse<gtsam::Pose3>, input); }},
-      {BetweenFactorPose2Tag,  [](json input) { return parseNoiseModel2<gtsam::Pose2, gtsam::BetweenFactor<gtsam::Pose2>>(&parse<gtsam::Pose2>, input); }},
-      {BetweenFactorPose3Tag,  [](json input) { return parseNoiseModel2<gtsam::Pose3, gtsam::BetweenFactor<gtsam::Pose3>>(&parse<gtsam::Pose3>, input); }},
-      {RangeFactorPose2Tag,    [](json input) { return parseNoiseModel2<double, gtsam::RangeFactor<gtsam::Pose2>>(&parse<double>, input); }},
-      {RangeFactorPose3Tag,    [](json input) { return parseNoiseModel2<double, gtsam::RangeFactor<gtsam::Pose3>>(&parse<double>, input); }},
-      {PriorFactorPoint2Tag,   [](json input) { return parsePrior<gtsam::Point2>(&parse<gtsam::Point2>, input); }},
-      {PriorFactorPoint3Tag,   [](json input) { return parsePrior<gtsam::Point3>(&parse<gtsam::Point3>, input); }},
-      {BetweenFactorPoint2Tag, [](json input) { return parseNoiseModel2<gtsam::Point2, gtsam::BetweenFactor<gtsam::Point2>>(&parse<gtsam::Point2>, input); }},
-      {BetweenFactorPoint3Tag, [](json input) { return parseNoiseModel2<gtsam::Point3, gtsam::BetweenFactor<gtsam::Point3>>(&parse<gtsam::Point3>, input); }},
+      {PriorFactorPose2Tag,         [](json input) { return parsePrior<gtsam::Pose2>(&parse<gtsam::Pose2>, input); }},
+      {PriorFactorPose3Tag,         [](json input) { return parsePrior<gtsam::Pose3>(&parse<gtsam::Pose3>, input); }},
+      {BetweenFactorPose2Tag,       [](json input) { return parseNoiseModel2<gtsam::Pose2, gtsam::BetweenFactor<gtsam::Pose2>>(&parse<gtsam::Pose2>, input); }},
+      {BetweenFactorPose3Tag,       [](json input) { return parseNoiseModel2<gtsam::Pose3, gtsam::BetweenFactor<gtsam::Pose3>>(&parse<gtsam::Pose3>, input); }},
+      {RangeFactorPose2Tag,         [](json input) { return parseNoiseModel2<double, gtsam::RangeFactor<gtsam::Pose2>>(&parse<double>, input); }},
+      {RangeFactorPose3Tag,         [](json input) { return parseNoiseModel2<double, gtsam::RangeFactor<gtsam::Pose3>>(&parse<double>, input); }},
+      {BearingRangeFactorPose2Tag,  [](json input) { return parseNoiseModel2<gtsam::BearingRange<gtsam::Pose2, gtsam::Pose2>, gtsam::BearingRangeFactor<gtsam::Pose2, gtsam::Pose2>>(&parseBearingRange<gtsam::Pose2, gtsam::Pose2>, input); }},
+      {BearingRangeFactorPose3Tag,  [](json input) { return parseNoiseModel2<gtsam::BearingRange<gtsam::Pose3, gtsam::Pose3>, gtsam::BearingRangeFactor<gtsam::Pose3, gtsam::Pose3>>(&parseBearingRange<gtsam::Pose3, gtsam::Pose3>, input); }},
+      {PriorFactorPoint2Tag,        [](json input) { return parsePrior<gtsam::Point2>(&parse<gtsam::Point2>, input); }},
+      {PriorFactorPoint3Tag,        [](json input) { return parsePrior<gtsam::Point3>(&parse<gtsam::Point3>, input); }},
+      {BetweenFactorPoint2Tag,      [](json input) { return parseNoiseModel2<gtsam::Point2, gtsam::BetweenFactor<gtsam::Point2>>(&parse<gtsam::Point2>, input); }},
+      {BetweenFactorPoint3Tag,      [](json input) { return parseNoiseModel2<gtsam::Point3, gtsam::BetweenFactor<gtsam::Point3>>(&parse<gtsam::Point3>, input); }},
   };
   // clang-format on
   return parser_functions;

--- a/src/Writer.cpp
+++ b/src/Writer.cpp
@@ -40,18 +40,20 @@ std::map<std::string, ValueSerializer> Writer::loadDefaultValueSerializers() {
 std::map<std::string, MeasurementSerializer> Writer::loadDefaultMeasurementSerializers() {
   // clang-format off
   std::map<std::string, MeasurementSerializer> serializer_functions = {
-    {PriorFactorPose2Tag,   [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializePrior<gtsam::Pose2>(&serialize<gtsam::Pose2>, PriorFactorPose2Tag, factor); }},
-    {PriorFactorPose3Tag,   [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializePrior<gtsam::Pose3>(&serialize<gtsam::Pose3>, PriorFactorPose3Tag, factor); }},
-    {BetweenFactorPose2Tag, [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<gtsam::Pose2, gtsam::BetweenFactor<gtsam::Pose2>>(&serialize<gtsam::Pose2>, BetweenFactorPose2Tag, factor); }},
-    {BetweenFactorPose3Tag, [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<gtsam::Pose3, gtsam::BetweenFactor<gtsam::Pose3>>(&serialize<gtsam::Pose3>, BetweenFactorPose3Tag, factor); }},
-    {RangeFactorPose2Tag,   [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<double, gtsam::RangeFactor<gtsam::Pose2>>(&serialize<double>, RangeFactorPose2Tag, factor); }},
-    {RangeFactorPose3Tag,   [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<double, gtsam::RangeFactor<gtsam::Pose3>>(&serialize<double>, RangeFactorPose3Tag, factor); }},
-    {PriorFactorPoint2Tag,   [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializePrior<gtsam::Point2>(&serialize<gtsam::Point2>, PriorFactorPoint2Tag, factor); }},
-    {PriorFactorPoint3Tag,   [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializePrior<gtsam::Point3>(&serialize<gtsam::Point3>, PriorFactorPoint3Tag, factor); }},
-    {BetweenFactorPoint2Tag, [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<gtsam::Point2, gtsam::BetweenFactor<gtsam::Point2>>(&serialize<gtsam::Point2>, BetweenFactorPoint2Tag, factor); }},
-    {BetweenFactorPoint3Tag, [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<gtsam::Point3, gtsam::BetweenFactor<gtsam::Point3>>(&serialize<gtsam::Point3>, BetweenFactorPoint2Tag, factor); }},
+    {PriorFactorPose2Tag,           [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializePrior<gtsam::Pose2>(&serialize<gtsam::Pose2>, PriorFactorPose2Tag, factor); }},
+    {PriorFactorPose3Tag,           [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializePrior<gtsam::Pose3>(&serialize<gtsam::Pose3>, PriorFactorPose3Tag, factor); }},
+    {BetweenFactorPose2Tag,         [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<gtsam::Pose2, gtsam::BetweenFactor<gtsam::Pose2>>(&serialize<gtsam::Pose2>, BetweenFactorPose2Tag, factor); }},
+    {BetweenFactorPose3Tag,         [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<gtsam::Pose3, gtsam::BetweenFactor<gtsam::Pose3>>(&serialize<gtsam::Pose3>, BetweenFactorPose3Tag, factor); }},
+    {RangeFactorPose2Tag,           [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<double, gtsam::RangeFactor<gtsam::Pose2>>(&serialize<double>, RangeFactorPose2Tag, factor); }},
+    {RangeFactorPose3Tag,           [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<double, gtsam::RangeFactor<gtsam::Pose3>>(&serialize<double>, RangeFactorPose3Tag, factor); }},
+    {BearingRangeFactorPose2Tag,    [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<gtsam::BearingRange<gtsam::Pose2, gtsam::Pose2>, gtsam::BearingRangeFactor<gtsam::Pose2, gtsam::Pose2>>(&serializeBearingRange<gtsam::Pose2, gtsam::Pose2>, BearingRangeFactorPose2Tag, factor); }},
+    {BearingRangeFactorPose3Tag,    [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<gtsam::BearingRange<gtsam::Pose3, gtsam::Pose3>, gtsam::BearingRangeFactor<gtsam::Pose3, gtsam::Pose3>>(&serializeBearingRange<gtsam::Pose3, gtsam::Pose3>, BearingRangeFactorPose3Tag, factor); }},
+    {PriorFactorPoint2Tag,          [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializePrior<gtsam::Point2>(&serialize<gtsam::Point2>, PriorFactorPoint2Tag, factor); }},
+    {PriorFactorPoint3Tag,          [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializePrior<gtsam::Point3>(&serialize<gtsam::Point3>, PriorFactorPoint3Tag, factor); }},
+    {BetweenFactorPoint2Tag,        [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<gtsam::Point2, gtsam::BetweenFactor<gtsam::Point2>>(&serialize<gtsam::Point2>, BetweenFactorPoint2Tag, factor); }},
+    {BetweenFactorPoint3Tag,        [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<gtsam::Point3, gtsam::BetweenFactor<gtsam::Point3>>(&serialize<gtsam::Point3>, BetweenFactorPoint2Tag, factor); }},
   };
-  // clang-format onRangeFactorPose3Tag
+  // clang-format on
 
   return serializer_functions;
 }
@@ -97,7 +99,7 @@ void Writer::writeJson(json output_json, std::string output_file_name, bool comp
     std::ofstream output_stream(output_file_name);
     output_stream << output_json;
     output_stream.close();
-  } 
+  }
 }
 
 /**********************************************************************************************************************/
@@ -137,7 +139,6 @@ void Writer::writeDataset(Dataset dataset, std::string output_file_name, bool co
   writeJson(output_json, output_file_name, compress_to_cbor);
 }
 
-
 /**********************************************************************************************************************/
 void Writer::writeResults(Results results, std::string output_file_name, bool compress_to_cbor) {
   json output_json;
@@ -166,9 +167,9 @@ void Writer::writeMetricSummary(MetricSummary metric_summary, std::string output
   output_json["method_name"] = metric_summary.method_name;
   output_json["robots"] = metric_summary.robots;
   if (metric_summary.robot_ate) output_json["robot_ate"] = *metric_summary.robot_ate;
-  if (metric_summary.total_ate)  output_json["total_ate"] = *metric_summary.total_ate;
-  if (metric_summary.sve)  output_json["sve"] = *metric_summary.sve;
-  if (metric_summary.mean_residual)  output_json["mean_residual"] = *metric_summary.mean_residual;
+  if (metric_summary.total_ate) output_json["total_ate"] = *metric_summary.total_ate;
+  if (metric_summary.sve) output_json["sve"] = *metric_summary.sve;
+  if (metric_summary.mean_residual) output_json["mean_residual"] = *metric_summary.mean_residual;
 
   // Write the file
   writeJson(output_json, output_file_name, compress_to_cbor);


### PR DESCRIPTION
Towards this goal there are a few things
1. Change IO methods to function as template specializations allowing better reuse
2. Add a bunch of supported Values (Rot2, Rot3, Unit3, BearingRange)
3. Add BearingRangeFactor support and bindings

One thing to note is the need to implement specific `serialize/parseBearingRange` functions. This is because c++ does not allow for partial template specialization. Maybe in a future standard c++ will allow this because it would make things much better, but alas.