### PR TITLE
Support for StereoFactor & CombinedImuFactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.16)
 project(jrl VERSION 0.0.2 LANGUAGES CXX C)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -70,3 +70,6 @@ add_custom_target(python-uninstall
 include(cmake/MakeConfigFile.cmake)
 MakeConfigFile(jrl)
 export(EXPORT jrl-exports FILE ${CMAKE_CURRENT_BINARY_DIR}/jrl-exports.cmake)
+
+# Tests
+add_subdirectory(tests)

--- a/include/jrl/DatasetBuilder.h
+++ b/include/jrl/DatasetBuilder.h
@@ -31,6 +31,10 @@ class DatasetBuilder {
                 const boost::optional<TypedValues> initialization = boost::none,
                 const boost::optional<TypedValues> groundtruth = boost::none);
 
+  void addGroundTruth(char robot, TypedValues groundtruth);
+
+  void addInitialization(char robot, TypedValues initialization);
+
   Dataset build();
 };
 }  // namespace jrl

--- a/include/jrl/IOMeasurements.h
+++ b/include/jrl/IOMeasurements.h
@@ -2,7 +2,6 @@
 #include <gtsam/geometry/Cal3_S2Stereo.h>
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/geometry/Pose3.h>
-#include <gtsam/geometry/StereoPoint2.h>
 #include <gtsam/navigation/CombinedImuFactor.h>
 #include <gtsam/nonlinear/PriorFactor.h>
 #include <gtsam/slam/BetweenFactor.h>
@@ -44,9 +43,6 @@ json serializeCovariance(gtsam::Matrix covariance);
 
 gtsam::Cal3_S2Stereo::shared_ptr parseCal3_S2Stereo(json input_json);
 json serializeCal3_S2Stereo(gtsam::Cal3_S2Stereo::shared_ptr calibration);
-
-gtsam::StereoPoint2 parseStereoPoint2(json input_json);
-json serializeStereoPoint2(gtsam::StereoPoint2 point);
 
 gtsam::NonlinearFactor::shared_ptr parseCombinedIMUFactor(json input_json);
 json serializeCombinedIMUFactor(std::string type_tag, gtsam::NonlinearFactor::shared_ptr& factor);
@@ -134,7 +130,7 @@ gtsam::NonlinearFactor::shared_ptr parseStereoFactor(std::function<POSE(json)> p
   }
 
   // Construct the factor
-  gtsam::StereoPoint2 measured = parseStereoPoint2(measurement_json);
+  gtsam::StereoPoint2 measured = io_values::parse<gtsam::StereoPoint2>(measurement_json);
   gtsam::Cal3_S2Stereo::shared_ptr calibration = parseCal3_S2Stereo(calibration_json);
   typename gtsam::GenericStereoFactor<POSE, LANDMARK>::shared_ptr factor =
       boost::make_shared<gtsam::GenericStereoFactor<gtsam::Pose3, gtsam::Point3>>(
@@ -158,7 +154,7 @@ json serializeStereoFactor(std::function<json(POSE)> pose_serializer_fn, std::st
   output["key_pose"] = stereo_factor->keys().front();
   output["key_landmark"] = stereo_factor->keys().back();
   output["covariance"] = serializeCovariance(noise_model->covariance());
-  output["measurement"] = serializeStereoPoint2(stereo_factor->measured());
+  output["measurement"] = io_values::serialize<gtsam::StereoPoint2>(stereo_factor->measured());
 
   // Extra stuff for this factor
   output["calibration"] = serializeCal3_S2Stereo(stereo_factor->calibration());

--- a/include/jrl/IOMeasurements.h
+++ b/include/jrl/IOMeasurements.h
@@ -1,8 +1,11 @@
 #pragma once
+#include <gtsam/geometry/Cal3_S2Stereo.h>
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/geometry/Pose3.h>
-#include <gtsam/slam/BetweenFactor.h>
+#include <gtsam/geometry/StereoPoint2.h>
 #include <gtsam/nonlinear/PriorFactor.h>
+#include <gtsam/slam/BetweenFactor.h>
+#include <gtsam/slam/StereoFactor.h>
 
 #include <nlohmann/json.hpp>
 using json = nlohmann::json;
@@ -19,12 +22,19 @@ static const std::string BetweenFactorPoint2Tag = "BetweenFactorPoint2";
 static const std::string BetweenFactorPoint3Tag = "BetweenFactorPoint3";
 static const std::string PriorFactorPoint2Tag = "PriorFactorPoint2";
 static const std::string PriorFactorPoint3Tag = "PriorFactorPoint3";
+static const std::string StereoFactorPose3Point3Tag = "StereoFactorPose3Point3";
 
 namespace io_measurements {
 
 /**********************************************************************************************************************/
 gtsam::Matrix parseCovariance(json input_json, int d);
 json serializeCovariance(gtsam::Matrix covariance);
+
+gtsam::Cal3_S2Stereo::shared_ptr parseCal3_S2Stereo(json input_json);
+json serializeCal3_S2Stereo(gtsam::Cal3_S2Stereo::shared_ptr calibration);
+
+gtsam::StereoPoint2 parseStereoPoint2(json input_json);
+json serializeStereoPoint2(gtsam::StereoPoint2 point);
 
 /**********************************************************************************************************************/
 template <typename T>
@@ -89,6 +99,59 @@ json serializeNoiseModel2(std::function<json(MEASURE)> val_serializer_fn, std::s
   output["key2"] = between->keys().back();
   output["measurement"] = val_serializer_fn(between->measured());
   output["covariance"] = serializeCovariance(noise_model->covariance());
+  return output;
+}
+
+/**********************************************************************************************************************/
+template <typename POSE, typename LANDMARK>
+gtsam::NonlinearFactor::shared_ptr parseStereoFactor(std::function<POSE(json)> pose_parser_fn, json input_json) {
+  // Get all required fields
+  json key_pose_json = input_json["key_pose"];
+  json key_landmark_json = input_json["key_landmark"];
+  json measurement_json = input_json["measurement"];
+  json calibration_json = input_json["calibration"];
+  json covariance_json = input_json["covariance"];
+
+  // Get optional field
+  boost::optional<POSE> body_T_sensor = boost::none;
+  if (input_json.contains("body_T_sensor")) {
+    body_T_sensor = pose_parser_fn(input_json["body_T_sensor"]);
+  }
+
+  // Construct the factor
+  gtsam::StereoPoint2 measured = parseStereoPoint2(measurement_json);
+  gtsam::Cal3_S2Stereo::shared_ptr calibration = parseCal3_S2Stereo(calibration_json);
+  typename gtsam::GenericStereoFactor<POSE, LANDMARK>::shared_ptr factor =
+      boost::make_shared<gtsam::GenericStereoFactor<gtsam::Pose3, gtsam::Point3>>(
+          measured, gtsam::noiseModel::Gaussian::Covariance(parseCovariance(covariance_json, 3)),
+          key_pose_json.get<uint64_t>(), key_landmark_json.get<uint64_t>(), calibration, body_T_sensor);
+
+  return factor;
+}
+
+template <typename POSE, typename LANDMARK>
+json serializeStereoFactor(std::function<json(POSE)> pose_serializer_fn, std::string type_tag,
+                           gtsam::NonlinearFactor::shared_ptr& factor) {
+  json output;
+  typename gtsam::GenericStereoFactor<POSE, LANDMARK>::shared_ptr stereo_factor =
+      boost::dynamic_pointer_cast<gtsam::GenericStereoFactor<POSE, LANDMARK>>(factor);
+  gtsam::noiseModel::Gaussian::shared_ptr noise_model =
+      boost::dynamic_pointer_cast<gtsam::noiseModel::Gaussian>(stereo_factor->noiseModel());
+
+  // Usual NoiseModel2 stuff
+  output["type"] = type_tag;
+  output["key_pose"] = stereo_factor->keys().front();
+  output["key_landmark"] = stereo_factor->keys().back();
+  output["covariance"] = serializeCovariance(noise_model->covariance());
+  output["measurement"] = serializeStereoPoint2(stereo_factor->measured());
+
+  // Extra stuff for this factor
+  output["calibration"] = serializeCal3_S2Stereo(stereo_factor->calibration());
+  // TODO: Make pull request on gtsam to add in this getter
+  // boost::optional<POSE> body_T_sensor = stereo_factor->body_P_sensor();
+  // if(body_T_sensor.is_initialized()){
+  //   output["body_T_sensor"] = pose_serializer_fn(body_T_sensor.get());
+  // }
   return output;
 }
 

--- a/include/jrl/IOMeasurements.h
+++ b/include/jrl/IOMeasurements.h
@@ -29,6 +29,7 @@ static const std::string BetweenFactorPoint2Tag = "BetweenFactorPoint2";
 static const std::string BetweenFactorPoint3Tag = "BetweenFactorPoint3";
 static const std::string PriorFactorPoint2Tag = "PriorFactorPoint2";
 static const std::string PriorFactorPoint3Tag = "PriorFactorPoint3";
+static const std::string PriorFactorIMUBiasTag = "PriorFactorIMUBias";
 static const std::string StereoFactorPose3Point3Tag = "StereoFactorPose3Point3";
 static const std::string CombinedIMUTag = "CombinedIMU";
 

--- a/include/jrl/IOValues.h
+++ b/include/jrl/IOValues.h
@@ -4,6 +4,7 @@
 #include <gtsam/geometry/Pose2.h>
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/nonlinear/Values.h>
+#include <gtsam/navigation/ImuBias.h>
 
 #include <nlohmann/json.hpp>
 using json = nlohmann::json;
@@ -19,6 +20,7 @@ static const std::string Unit3Tag = "Unit3";
 static const std::string VectorTag = "Vector";
 static const std::string ScalarTag = "Scalar";
 static const std::string BearingRangeTag = "BearingRange";
+static const std::string IMUBiasTag = "IMUBias";
 
 namespace io_values {
 
@@ -57,7 +59,7 @@ template <>
 json serialize<gtsam::Pose2>(gtsam::Pose2 pose);
 
 /**********************************************************************************************************************/
-// Rot2
+// Rot3
 template <>
 gtsam::Rot3 parse<gtsam::Rot3>(json input_json);
 template <>
@@ -97,6 +99,13 @@ template <>
 gtsam::Unit3 parse<gtsam::Unit3>(json input_json);
 template <>
 json serialize<gtsam::Unit3>(gtsam::Unit3 point);
+
+/**********************************************************************************************************************/
+// ConstantBias
+template <>
+gtsam::imuBias::ConstantBias parse<gtsam::imuBias::ConstantBias>(json input_json);
+template <>
+json serialize<gtsam::imuBias::ConstantBias>(gtsam::imuBias::ConstantBias point);
 
 /**********************************************************************************************************************/
 // BearingRange Need special treatment because c++ does not allow function partial specialization

--- a/include/jrl/IOValues.h
+++ b/include/jrl/IOValues.h
@@ -5,6 +5,7 @@
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/nonlinear/Values.h>
 #include <gtsam/navigation/ImuBias.h>
+#include <gtsam/geometry/StereoPoint2.h>
 
 #include <nlohmann/json.hpp>
 using json = nlohmann::json;
@@ -106,6 +107,13 @@ template <>
 gtsam::imuBias::ConstantBias parse<gtsam::imuBias::ConstantBias>(json input_json);
 template <>
 json serialize<gtsam::imuBias::ConstantBias>(gtsam::imuBias::ConstantBias point);
+
+/**********************************************************************************************************************/
+// ConstantBias
+template <>
+gtsam::StereoPoint2 parse<gtsam::StereoPoint2>(json input_json);
+template <>
+json serialize<gtsam::StereoPoint2>(gtsam::StereoPoint2 point);
 
 /**********************************************************************************************************************/
 // BearingRange Need special treatment because c++ does not allow function partial specialization

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -42,6 +42,8 @@ PYBIND11_MODULE(jrl_python, m) {
   m.attr("PriorFactorPointTag") = py::str(PriorFactorPoint3Tag);
   m.attr("BetweenFactorPoint2Tag") = py::str(BetweenFactorPoint2Tag);
   m.attr("BetweenFactorPoint3Tag") = py::str(BetweenFactorPoint3Tag);
+  m.attr("StereoFactorPose3Point3Tag") = py::str(StereoFactorPose3Point3Tag);
+  m.attr("CombinedIMUTag") = py::str(CombinedIMUTag);
 
   /**
    * ########     ###    ########    ###     ######  ######## ########

--- a/src/DatasetBuilder.cpp
+++ b/src/DatasetBuilder.cpp
@@ -18,14 +18,22 @@ void DatasetBuilder::addEntry(char robot, uint64_t stamp, gtsam::NonlinearFactor
                               const boost::optional<TypedValues> groundtruth) {
   measurements_[robot].push_back(Entry(stamp, measurement_types, measurements));
   if (initialization) {
-    initial_estimates_[robot].values.insert((*initialization).values);
-    initial_estimates_[robot].types.insert((*initialization).types.begin(), (*initialization).types.end());
+    addInitialization(robot, *initialization);
   }
 
   if (groundtruth) {
-    ground_truth_[robot].values.insert((*groundtruth).values);
-    ground_truth_[robot].types.insert((*groundtruth).types.begin(), (*groundtruth).types.end());
+    addGroundTruth(robot, *groundtruth);
   }
+}
+
+void DatasetBuilder::addGroundTruth(char robot, TypedValues groundtruth){
+  ground_truth_[robot].values.insert(groundtruth.values);
+  ground_truth_[robot].types.insert(groundtruth.types.begin(), groundtruth.types.end());
+}
+
+void DatasetBuilder::addInitialization(char robot, TypedValues initialization){
+  initial_estimates_[robot].values.insert(initialization.values);
+  initial_estimates_[robot].types.insert(initialization.types.begin(), initialization.types.end());
 }
 
 Dataset DatasetBuilder::build() {

--- a/src/IOMeasurements.cpp
+++ b/src/IOMeasurements.cpp
@@ -81,8 +81,7 @@ gtsam::NonlinearFactor::shared_ptr parseCombinedIMUFactor(json input_json) {
   gtsam::Matrix H_biassAcc = parseMatrix(input_json["H_biasAcc"], 9, 3);
   gtsam::Matrix H_biassOmega = parseMatrix(input_json["H_biasOmega"], 9, 3);
   double deltaTij = io_values::parse<double>(input_json["deltaTij"]);
-  gtsam::Vector biasHat_vec = io_values::parse<gtsam::Vector>(input_json["biasHat"]);
-  gtsam::imuBias::ConstantBias biasHat(biasHat_vec);
+  gtsam::imuBias::ConstantBias biasHat = io_values::parse<gtsam::imuBias::ConstantBias>(input_json["biasHat"]);
   gtsam::TangentPreintegration tang_pim(params, deltaXij, H_biassAcc, H_biassOmega, biasHat, deltaTij);
 
   // Now turn it into CombinedPreintegration
@@ -118,7 +117,7 @@ json serializeCombinedIMUFactor(std::string type_tag, gtsam::NonlinearFactor::sh
   output["H_biasAcc"] = serializeMatrix(pim.preintegrated_H_biasAcc());
   output["H_biasOmega"] = serializeMatrix(pim.preintegrated_H_biasOmega());
   output["deltaTij"] = io_values::serialize(pim.deltaTij());
-  output["biasHat"] = io_values::serialize<gtsam::Vector>(pim.biasHatVector());
+  output["biasHat"] = io_values::serialize<gtsam::imuBias::ConstantBias>(pim.biasHat());
 
   // PreintegrationParams
   boost::shared_ptr<gtsam::PreintegrationCombinedParams> params =

--- a/src/IOMeasurements.cpp
+++ b/src/IOMeasurements.cpp
@@ -7,6 +7,7 @@ namespace jrl {
 namespace io_measurements {
 
 /**********************************************************************************************************************/
+// Covariance
 gtsam::Matrix parseCovariance(json input_json, int d) {
   auto v = input_json.get<std::vector<double>>();
   gtsam::Matrix m = Eigen::Map<gtsam::Matrix>(v.data(), d, d);
@@ -16,6 +17,46 @@ gtsam::Matrix parseCovariance(json input_json, int d) {
 json serializeCovariance(gtsam::Matrix covariance) {
   std::vector<double> vec(covariance.data(), covariance.data() + covariance.rows() * covariance.cols());
   return json(vec);
+}
+
+/**********************************************************************************************************************/
+// Cal3_S2Stereo
+gtsam::Cal3_S2Stereo::shared_ptr parseCal3_S2Stereo(json input_json) {
+  double fx = input_json["fx"].get<double>();
+  double fy = input_json["fy"].get<double>();
+  double skew = input_json["skew"].get<double>();
+  double px = input_json["px"].get<double>();
+  double py = input_json["py"].get<double>();
+  double baseline = input_json["baseline"].get<double>();
+  return boost::make_shared<gtsam::Cal3_S2Stereo>(fx, fy, skew, px, py, baseline);
+}
+
+json serializeCal3_S2Stereo(gtsam::Cal3_S2Stereo::shared_ptr calibration) {
+  json output;
+  output["fx"] = calibration->fx();
+  output["fy"] = calibration->fy();
+  output["skew"] = calibration->skew();
+  output["px"] = calibration->px();
+  output["py"] = calibration->py();
+  output["baseline"] = calibration->baseline();
+  return output;
+}
+
+/**********************************************************************************************************************/
+// StereoPoint2
+gtsam::StereoPoint2 parseStereoPoint2(json input_json) {
+  double uL = input_json["uL"].get<double>();
+  double uR = input_json["uR"].get<double>();
+  double v = input_json["v"].get<double>();
+  return gtsam::StereoPoint2(uL, uR, v);
+}
+
+json serializeStereoPoint2(gtsam::StereoPoint2 point) {
+  json output;
+  output["uL"] = point.uL();
+  output["uR"] = point.uR();
+  output["v"] = point.v();
+  return output;
 }
 
 }  // namespace io_measurements

--- a/src/IOMeasurements.cpp
+++ b/src/IOMeasurements.cpp
@@ -114,11 +114,11 @@ json serializeCombinedIMUFactor(std::string type_tag, gtsam::NonlinearFactor::sh
     output["key" + std::to_string(i)] = imu_factor->keys()[i];
   }
   output["covariance"] = serializeCovariance(noise_model->covariance());
-  // output["deltaXij"] = io_values::serialize(pim.preintegrated());
+  output["deltaXij"] = io_values::serialize<gtsam::Vector>(pim.preintegrated());
   output["H_biasAcc"] = serializeMatrix(pim.preintegrated_H_biasAcc());
   output["H_biasOmega"] = serializeMatrix(pim.preintegrated_H_biasOmega());
-  // output["deltaTij"] = io_values::serialize(pim.deltaTij());
-  // output["biasHat"] = io_values::serialize(pim.biasHatVector());
+  output["deltaTij"] = io_values::serialize(pim.deltaTij());
+  output["biasHat"] = io_values::serialize<gtsam::Vector>(pim.biasHatVector());
 
   // PreintegrationParams
   boost::shared_ptr<gtsam::PreintegrationCombinedParams> params =
@@ -129,7 +129,7 @@ json serializeCombinedIMUFactor(std::string type_tag, gtsam::NonlinearFactor::sh
   output["biasGyroCov"] = serializeCovariance(params->biasOmegaCovariance);
   output["biasAccOmegaInt"] = serializeCovariance(params->biasAccOmegaInt);
   output["intCov"] = serializeCovariance(params->integrationCovariance);
-  // output["g"] = io_values::serialize(params->n_gravity);
+  output["g"] = io_values::serialize<gtsam::Vector>(params->n_gravity);
 
   // omegaCoriolis
   // body_P_sensor

--- a/src/IOMeasurements.cpp
+++ b/src/IOMeasurements.cpp
@@ -8,16 +8,20 @@ namespace io_measurements {
 
 /**********************************************************************************************************************/
 // Covariance
-gtsam::Matrix parseCovariance(json input_json, int d) {
+gtsam::Matrix parseMatrix(json input_json, int row, int col) {
   auto v = input_json.get<std::vector<double>>();
-  gtsam::Matrix m = Eigen::Map<gtsam::Matrix>(v.data(), d, d);
+  gtsam::Matrix m = Eigen::Map<gtsam::Matrix>(v.data(), row, col);
   return m;
 }
 
-json serializeCovariance(gtsam::Matrix covariance) {
-  std::vector<double> vec(covariance.data(), covariance.data() + covariance.rows() * covariance.cols());
+json serializeMatrix(gtsam::Matrix mat) {
+  std::vector<double> vec(mat.data(), mat.data() + mat.rows() * mat.cols());
   return json(vec);
 }
+
+gtsam::Matrix parseCovariance(json input_json, int d) { return parseMatrix(input_json, d, d); }
+
+json serializeCovariance(gtsam::Matrix covariance) { return serializeMatrix(covariance); }
 
 /**********************************************************************************************************************/
 // Cal3_S2Stereo
@@ -56,6 +60,80 @@ json serializeStereoPoint2(gtsam::StereoPoint2 point) {
   output["uL"] = point.uL();
   output["uR"] = point.uR();
   output["v"] = point.v();
+  return output;
+}
+
+/**********************************************************************************************************************/
+// IMUFactor
+gtsam::NonlinearFactor::shared_ptr parseCombinedIMUFactor(json input_json) {
+  // First construct Params
+  boost::shared_ptr<gtsam::PreintegrationCombinedParams> params = gtsam::PreintegrationCombinedParams::MakeSharedU();
+  params->accelerometerCovariance = parseCovariance(input_json["accCov"], 3);
+  params->gyroscopeCovariance = parseCovariance(input_json["gyroCov"], 3);
+  params->biasAccCovariance = parseCovariance(input_json["biasAccCov"], 3);
+  params->biasOmegaCovariance = parseCovariance(input_json["biasGyroCov"], 3);
+  params->biasAccOmegaInt = parseCovariance(input_json["biasAccOmegaInt"], 6);
+  params->integrationCovariance = parseCovariance(input_json["intCov"], 3);
+  params->n_gravity = io_values::parseVector(input_json["g"]);
+
+  // Then construct TangentPreintegration
+  gtsam::Vector deltaXij = io_values::parseVector(input_json["deltaXij"]);
+  gtsam::Matrix H_biassAcc = parseMatrix(input_json["H_biasAcc"], 9, 3);
+  gtsam::Matrix H_biassOmega = parseMatrix(input_json["H_biasOmega"], 9, 3);
+  double deltaTij = io_values::parseScalar<double>(input_json["deltaTij"]);
+  gtsam::Vector biasHat_vec = io_values::parseVector(input_json["biasHat"]);
+  gtsam::imuBias::ConstantBias biasHat(biasHat_vec);
+  gtsam::TangentPreintegration tang_pim(params, deltaXij, H_biassAcc, H_biassOmega, biasHat, deltaTij);
+
+  // Now turn it into CombinedPreintegration
+  gtsam::Matrix cov = parseCovariance(input_json["covariance"], 15);
+  gtsam::PreintegratedCombinedMeasurements pim(tang_pim, cov);
+
+  // And finally into a factor
+  uint64_t xi = input_json["key0"].get<uint64_t>();
+  uint64_t vi = input_json["key1"].get<uint64_t>();
+  uint64_t xj = input_json["key2"].get<uint64_t>();
+  uint64_t vj = input_json["key3"].get<uint64_t>();
+  uint64_t bi = input_json["key4"].get<uint64_t>();
+  uint64_t bj = input_json["key5"].get<uint64_t>();
+  gtsam::CombinedImuFactor::shared_ptr factor =
+      boost::make_shared<gtsam::CombinedImuFactor>(xi, vi, xj, vj, bi, bj, pim);
+  return factor;
+}
+
+json serializeCombinedIMUFactor(std::string type_tag, gtsam::NonlinearFactor::shared_ptr& factor) {
+  json output;
+  typename gtsam::CombinedImuFactor::shared_ptr imu_factor =
+      boost::dynamic_pointer_cast<gtsam::CombinedImuFactor>(factor);
+  gtsam::noiseModel::Gaussian::shared_ptr noise_model =
+      boost::dynamic_pointer_cast<gtsam::noiseModel::Gaussian>(imu_factor->noiseModel());
+  gtsam::PreintegratedCombinedMeasurements pim = imu_factor->preintegratedMeasurements();
+
+  output["type"] = type_tag;
+  for (int i = 0; i < 6; i++) {
+    output["key" + std::to_string(i)] = imu_factor->keys()[i];
+  }
+  output["covariance"] = serializeCovariance(noise_model->covariance());
+  output["deltaXij"] = io_values::serializeVector(pim.preintegrated());
+  output["H_biasAcc"] = serializeMatrix(pim.preintegrated_H_biasAcc());
+  output["H_biasOmega"] = serializeMatrix(pim.preintegrated_H_biasOmega());
+  output["deltaTij"] = io_values::serializeScalar(pim.deltaTij());
+  output["biasHat"] = io_values::serializeVector(pim.biasHatVector());
+
+  // PreintegrationParams
+  boost::shared_ptr<gtsam::PreintegrationCombinedParams> params =
+      boost::dynamic_pointer_cast<gtsam::PreintegrationCombinedParams>(pim.params());
+  output["accCov"] = serializeCovariance(params->accelerometerCovariance);
+  output["gyroCov"] = serializeCovariance(params->gyroscopeCovariance);
+  output["biasAccCov"] = serializeCovariance(params->biasAccCovariance);
+  output["biasGyroCov"] = serializeCovariance(params->biasOmegaCovariance);
+  output["biasAccOmegaInt"] = serializeCovariance(params->biasAccOmegaInt);
+  output["intCov"] = serializeCovariance(params->integrationCovariance);
+  output["g"] = io_values::serializeVector(params->n_gravity);
+
+  // omegaCoriolis
+  // body_P_sensor
+
   return output;
 }
 

--- a/src/IOMeasurements.cpp
+++ b/src/IOMeasurements.cpp
@@ -46,22 +46,6 @@ json serializeCal3_S2Stereo(gtsam::Cal3_S2Stereo::shared_ptr calibration) {
   return output;
 }
 
-/**********************************************************************************************************************/
-// StereoPoint2
-gtsam::StereoPoint2 parseStereoPoint2(json input_json) {
-  double uL = input_json["uL"].get<double>();
-  double uR = input_json["uR"].get<double>();
-  double v = input_json["v"].get<double>();
-  return gtsam::StereoPoint2(uL, uR, v);
-}
-
-json serializeStereoPoint2(gtsam::StereoPoint2 point) {
-  json output;
-  output["uL"] = point.uL();
-  output["uR"] = point.uR();
-  output["v"] = point.v();
-  return output;
-}
 
 /**********************************************************************************************************************/
 // IMUFactor

--- a/src/IOValues.cpp
+++ b/src/IOValues.cpp
@@ -157,6 +157,21 @@ json serialize<gtsam::Unit3>(gtsam::Unit3 unit) {
   return output;
 }
 
+/**********************************************************************************************************************/
+// ConstantBias
+template <>
+gtsam::imuBias::ConstantBias parse<gtsam::imuBias::ConstantBias>(json input_json){
+  gtsam::Vector b = parse<gtsam::Vector>(input_json);
+  return gtsam::imuBias::ConstantBias(b);
+}
+
+template <>
+json serialize<gtsam::imuBias::ConstantBias>(gtsam::imuBias::ConstantBias point){
+  json output = serialize<gtsam::Vector>(point.vector());
+  output["type"] = IMUBiasTag;
+  return output;
+}
+
 
 }  // namespace io_values
 }  // namespace jrl

--- a/src/IOValues.cpp
+++ b/src/IOValues.cpp
@@ -43,7 +43,7 @@ json serialize<gtsam::Pose2>(gtsam::Pose2 pose) {
 }
 
 /**********************************************************************************************************************/
-// Rot2
+// Rot3
 template <>
 gtsam::Rot3 parse<gtsam::Rot3>(json input_json) {
   std::vector<double> q = input_json["rotation"].get<std::vector<double>>();

--- a/src/IOValues.cpp
+++ b/src/IOValues.cpp
@@ -172,6 +172,25 @@ json serialize<gtsam::imuBias::ConstantBias>(gtsam::imuBias::ConstantBias point)
   return output;
 }
 
+/**********************************************************************************************************************/
+// StereoPoint2
+template <>
+gtsam::StereoPoint2 parse<gtsam::StereoPoint2>(json input_json) {
+  double uL = input_json["uL"].get<double>();
+  double uR = input_json["uR"].get<double>();
+  double v = input_json["v"].get<double>();
+  return gtsam::StereoPoint2(uL, uR, v);
+}
+
+template <>
+json serialize<gtsam::StereoPoint2>(gtsam::StereoPoint2 point) {
+  json output;
+  output["uL"] = point.uL();
+  output["uR"] = point.uR();
+  output["v"] = point.v();
+  return output;
+}
+
 
 }  // namespace io_values
 }  // namespace jrl

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -52,6 +52,7 @@ std::map<std::string, MeasurementParser> Parser::loadDefaultMeasurementParsers()
       {BetweenFactorPoint2Tag,      [](json input) { return parseNoiseModel2<gtsam::Point2, gtsam::BetweenFactor<gtsam::Point2>>(&parse<gtsam::Point2>, input); }},
       {BetweenFactorPoint3Tag,      [](json input) { return parseNoiseModel2<gtsam::Point3, gtsam::BetweenFactor<gtsam::Point3>>(&parse<gtsam::Point3>, input); }},
       {StereoFactorPose3Point3Tag,  [](json input) { return parseStereoFactor<gtsam::Pose3, gtsam::Point3>(&parse<gtsam::Pose3>, input); }},
+      {PriorFactorIMUBiasTag,       [](json input) { return parsePrior<gtsam::imuBias::ConstantBias>(&parse<gtsam::imuBias::ConstantBias>, input); }},
       {CombinedIMUTag,              [](json input) { return parseCombinedIMUFactor(input); }},
   };
   // clang-format on

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -5,6 +5,7 @@
 #include <gtsam/slam/PriorFactor.h>
 
 #include <fstream>
+
 #include "jrl/IOMeasurements.h"
 #include "jrl/IOValues.h"
 
@@ -37,16 +38,17 @@ std::map<std::string, ValueParser> Parser::loadDefaultValueAccumulators() {
 std::map<std::string, MeasurementParser> Parser::loadDefaultMeasurementParsers() {
   // clang-format off
   std::map<std::string, MeasurementParser> parser_functions = {
-      {PriorFactorPose2Tag,    [](json input) { return parsePrior<gtsam::Pose2>(&parsePose2, input); }},
-      {PriorFactorPose3Tag,    [](json input) { return parsePrior<gtsam::Pose3>(&parsePose3, input); }},
-      {BetweenFactorPose2Tag,  [](json input) { return parseNoiseModel2<gtsam::Pose2, gtsam::BetweenFactor<gtsam::Pose2>>(&parsePose2, input); }},
-      {BetweenFactorPose3Tag,  [](json input) { return parseNoiseModel2<gtsam::Pose3, gtsam::BetweenFactor<gtsam::Pose3>>(&parsePose3, input); }},
-      {RangeFactorPose2Tag,    [](json input) { return parseNoiseModel2<double, gtsam::RangeFactor<gtsam::Pose2>>(&parseScalar<double>, input); }},
-      {RangeFactorPose3Tag,    [](json input) { return parseNoiseModel2<double, gtsam::RangeFactor<gtsam::Pose3>>(&parseScalar<double>, input); }},
-      {PriorFactorPoint2Tag,   [](json input) { return parsePrior<gtsam::Point2>(&parsePoint2, input); }},
-      {PriorFactorPoint3Tag,   [](json input) { return parsePrior<gtsam::Point3>(&parsePoint3, input); }},
-      {BetweenFactorPoint2Tag, [](json input) { return parseNoiseModel2<gtsam::Point2, gtsam::BetweenFactor<gtsam::Point2>>(&parsePoint2, input); }},
-      {BetweenFactorPoint3Tag, [](json input) { return parseNoiseModel2<gtsam::Point3, gtsam::BetweenFactor<gtsam::Point3>>(&parsePoint3, input); }},
+      {PriorFactorPose2Tag,        [](json input) { return parsePrior<gtsam::Pose2>(&parsePose2, input); }},
+      {PriorFactorPose3Tag,        [](json input) { return parsePrior<gtsam::Pose3>(&parsePose3, input); }},
+      {BetweenFactorPose2Tag,      [](json input) { return parseNoiseModel2<gtsam::Pose2, gtsam::BetweenFactor<gtsam::Pose2>>(&parsePose2, input); }},
+      {BetweenFactorPose3Tag,      [](json input) { return parseNoiseModel2<gtsam::Pose3, gtsam::BetweenFactor<gtsam::Pose3>>(&parsePose3, input); }},
+      {RangeFactorPose2Tag,        [](json input) { return parseNoiseModel2<double, gtsam::RangeFactor<gtsam::Pose2>>(&parseScalar<double>, input); }},
+      {RangeFactorPose3Tag,        [](json input) { return parseNoiseModel2<double, gtsam::RangeFactor<gtsam::Pose3>>(&parseScalar<double>, input); }},
+      {PriorFactorPoint2Tag,       [](json input) { return parsePrior<gtsam::Point2>(&parsePoint2, input); }},
+      {PriorFactorPoint3Tag,       [](json input) { return parsePrior<gtsam::Point3>(&parsePoint3, input); }},
+      {BetweenFactorPoint2Tag,     [](json input) { return parseNoiseModel2<gtsam::Point2, gtsam::BetweenFactor<gtsam::Point2>>(&parsePoint2, input); }},
+      {BetweenFactorPoint3Tag,     [](json input) { return parseNoiseModel2<gtsam::Point3, gtsam::BetweenFactor<gtsam::Point3>>(&parsePoint3, input); }},
+      {StereoFactorPose3Point3Tag, [](json input) { return parseStereoFactor<gtsam::Pose3, gtsam::Point3>(&parsePose3, input); }},
   };
   // clang-format on
   return parser_functions;

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -49,6 +49,7 @@ std::map<std::string, MeasurementParser> Parser::loadDefaultMeasurementParsers()
       {BetweenFactorPoint2Tag,     [](json input) { return parseNoiseModel2<gtsam::Point2, gtsam::BetweenFactor<gtsam::Point2>>(&parsePoint2, input); }},
       {BetweenFactorPoint3Tag,     [](json input) { return parseNoiseModel2<gtsam::Point3, gtsam::BetweenFactor<gtsam::Point3>>(&parsePoint3, input); }},
       {StereoFactorPose3Point3Tag, [](json input) { return parseStereoFactor<gtsam::Pose3, gtsam::Point3>(&parsePose3, input); }},
+      {CombinedIMUTag,             [](json input) { return parseCombinedIMUFactor(input); }},
   };
   // clang-format on
   return parser_functions;

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -23,12 +23,13 @@ Parser::Parser() {
 std::map<std::string, ValueParser> Parser::loadDefaultValueAccumulators() {
   // clang-format off
   std::map<std::string, ValueParser> parser_functions = {
-      {Pose2Tag,  [](json input, gtsam::Key key, gtsam::Values& accum) { return valueAccumulator<gtsam::Pose2>(&parse<gtsam::Pose2>, input, key, accum); }},
-      {Pose3Tag,  [](json input, gtsam::Key key, gtsam::Values& accum) { return valueAccumulator<gtsam::Pose3>(&parse<gtsam::Pose3>, input, key, accum); }},
-      {Point2Tag, [](json input, gtsam::Key key, gtsam::Values& accum) { return valueAccumulator<gtsam::Point2>(&parse<gtsam::Point2>, input, key, accum); }},
-      {Point3Tag, [](json input, gtsam::Key key, gtsam::Values& accum) { return valueAccumulator<gtsam::Point3>(&parse<gtsam::Point3>, input, key, accum); }},
-      {VectorTag, [](json input, gtsam::Key key, gtsam::Values& accum) { return valueAccumulator<gtsam::Vector>(&parse<gtsam::Vector>, input, key, accum); }},
-      {ScalarTag, [](json input, gtsam::Key key, gtsam::Values& accum) { return valueAccumulator<double>(&parse<double>, input, key, accum); }},
+      {Pose2Tag,   [](json input, gtsam::Key key, gtsam::Values& accum) { return valueAccumulator<gtsam::Pose2>(&parse<gtsam::Pose2>, input, key, accum); }},
+      {Pose3Tag,   [](json input, gtsam::Key key, gtsam::Values& accum) { return valueAccumulator<gtsam::Pose3>(&parse<gtsam::Pose3>, input, key, accum); }},
+      {Point2Tag,  [](json input, gtsam::Key key, gtsam::Values& accum) { return valueAccumulator<gtsam::Point2>(&parse<gtsam::Point2>, input, key, accum); }},
+      {Point3Tag,  [](json input, gtsam::Key key, gtsam::Values& accum) { return valueAccumulator<gtsam::Point3>(&parse<gtsam::Point3>, input, key, accum); }},
+      {VectorTag,  [](json input, gtsam::Key key, gtsam::Values& accum) { return valueAccumulator<gtsam::Vector>(&parse<gtsam::Vector>, input, key, accum); }},
+      {ScalarTag,  [](json input, gtsam::Key key, gtsam::Values& accum) { return valueAccumulator<double>(&parse<double>, input, key, accum); }},
+      {IMUBiasTag, [](json input, gtsam::Key key, gtsam::Values& accum) { return valueAccumulator<gtsam::imuBias::ConstantBias>(&parse<gtsam::imuBias::ConstantBias>, input, key, accum); }},
   };
   // clang-format on
   return parser_functions;

--- a/src/Writer.cpp
+++ b/src/Writer.cpp
@@ -54,6 +54,7 @@ std::map<std::string, MeasurementSerializer> Writer::loadDefaultMeasurementSeria
     {BetweenFactorPoint2Tag,        [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<gtsam::Point2, gtsam::BetweenFactor<gtsam::Point2>>(&serialize<gtsam::Point2>, BetweenFactorPoint2Tag, factor); }},
     {BetweenFactorPoint3Tag,        [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<gtsam::Point3, gtsam::BetweenFactor<gtsam::Point3>>(&serialize<gtsam::Point3>, BetweenFactorPoint2Tag, factor); }},
     {StereoFactorPose3Point3Tag,    [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeStereoFactor<gtsam::Pose3, gtsam::Point3>(&serialize<gtsam::Pose3>, StereoFactorPose3Point3Tag, factor); }},
+    {PriorFactorIMUBiasTag,         [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializePrior<gtsam::imuBias::ConstantBias>(&serialize<gtsam::imuBias::ConstantBias>, PriorFactorIMUBiasTag, factor); }},
     {CombinedIMUTag,                [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeCombinedIMUFactor(CombinedIMUTag, factor); }},
   };
   // clang-format on

--- a/src/Writer.cpp
+++ b/src/Writer.cpp
@@ -51,6 +51,7 @@ std::map<std::string, MeasurementSerializer> Writer::loadDefaultMeasurementSeria
     {BetweenFactorPoint2Tag,     [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<gtsam::Point2, gtsam::BetweenFactor<gtsam::Point2>>(&serializePoint2, BetweenFactorPoint2Tag, factor); }},
     {BetweenFactorPoint3Tag,     [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<gtsam::Point3, gtsam::BetweenFactor<gtsam::Point3>>(&serializePoint3, BetweenFactorPoint2Tag, factor); }},
     {StereoFactorPose3Point3Tag, [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeStereoFactor<gtsam::Pose3, gtsam::Point3>(&serializePose3, StereoFactorPose3Point3Tag, factor); }},
+    {CombinedIMUTag,             [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeCombinedIMUFactor(CombinedIMUTag, factor); }},
   };
   // clang-format onRangeFactorPose3Tag
 

--- a/src/Writer.cpp
+++ b/src/Writer.cpp
@@ -40,16 +40,17 @@ std::map<std::string, ValueSerializer> Writer::loadDefaultValueSerializers() {
 std::map<std::string, MeasurementSerializer> Writer::loadDefaultMeasurementSerializers() {
   // clang-format off
   std::map<std::string, MeasurementSerializer> serializer_functions = {
-    {PriorFactorPose2Tag,   [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializePrior<gtsam::Pose2>(&serializePose2, PriorFactorPose2Tag, factor); }},
-    {PriorFactorPose3Tag,   [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializePrior<gtsam::Pose3>(&serializePose3, PriorFactorPose3Tag, factor); }},
-    {BetweenFactorPose2Tag, [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<gtsam::Pose2, gtsam::BetweenFactor<gtsam::Pose2>>(&serializePose2, BetweenFactorPose2Tag, factor); }},
-    {BetweenFactorPose3Tag, [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<gtsam::Pose3, gtsam::BetweenFactor<gtsam::Pose3>>(&serializePose3, BetweenFactorPose3Tag, factor); }},
-    {RangeFactorPose2Tag,   [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<double, gtsam::RangeFactor<gtsam::Pose2>>(&serializeScalar<double>, RangeFactorPose2Tag, factor); }},
-    {RangeFactorPose3Tag,   [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<double, gtsam::RangeFactor<gtsam::Pose3>>(&serializeScalar<double>, RangeFactorPose3Tag, factor); }},
-    {PriorFactorPoint2Tag,   [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializePrior<gtsam::Point2>(&serializePoint2, PriorFactorPoint2Tag, factor); }},
-    {PriorFactorPoint3Tag,   [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializePrior<gtsam::Point3>(&serializePoint3, PriorFactorPoint3Tag, factor); }},
-    {BetweenFactorPoint2Tag, [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<gtsam::Point2, gtsam::BetweenFactor<gtsam::Point2>>(&serializePoint2, BetweenFactorPoint2Tag, factor); }},
-    {BetweenFactorPoint3Tag, [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<gtsam::Point3, gtsam::BetweenFactor<gtsam::Point3>>(&serializePoint3, BetweenFactorPoint2Tag, factor); }},
+    {PriorFactorPose2Tag,        [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializePrior<gtsam::Pose2>(&serializePose2, PriorFactorPose2Tag, factor); }},
+    {PriorFactorPose3Tag,        [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializePrior<gtsam::Pose3>(&serializePose3, PriorFactorPose3Tag, factor); }},
+    {BetweenFactorPose2Tag,      [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<gtsam::Pose2, gtsam::BetweenFactor<gtsam::Pose2>>(&serializePose2, BetweenFactorPose2Tag, factor); }},
+    {BetweenFactorPose3Tag,      [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<gtsam::Pose3, gtsam::BetweenFactor<gtsam::Pose3>>(&serializePose3, BetweenFactorPose3Tag, factor); }},
+    {RangeFactorPose2Tag,        [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<double, gtsam::RangeFactor<gtsam::Pose2>>(&serializeScalar<double>, RangeFactorPose2Tag, factor); }},
+    {RangeFactorPose3Tag,        [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<double, gtsam::RangeFactor<gtsam::Pose3>>(&serializeScalar<double>, RangeFactorPose3Tag, factor); }},
+    {PriorFactorPoint2Tag,       [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializePrior<gtsam::Point2>(&serializePoint2, PriorFactorPoint2Tag, factor); }},
+    {PriorFactorPoint3Tag,       [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializePrior<gtsam::Point3>(&serializePoint3, PriorFactorPoint3Tag, factor); }},
+    {BetweenFactorPoint2Tag,     [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<gtsam::Point2, gtsam::BetweenFactor<gtsam::Point2>>(&serializePoint2, BetweenFactorPoint2Tag, factor); }},
+    {BetweenFactorPoint3Tag,     [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeNoiseModel2<gtsam::Point3, gtsam::BetweenFactor<gtsam::Point3>>(&serializePoint3, BetweenFactorPoint2Tag, factor); }},
+    {StereoFactorPose3Point3Tag, [](gtsam::NonlinearFactor::shared_ptr& factor) { return serializeStereoFactor<gtsam::Pose3, gtsam::Point3>(&serializePose3, StereoFactorPose3Point3Tag, factor); }},
   };
   // clang-format onRangeFactorPose3Tag
 

--- a/src/Writer.cpp
+++ b/src/Writer.cpp
@@ -25,12 +25,13 @@ Writer::Writer() {
 std::map<std::string, ValueSerializer> Writer::loadDefaultValueSerializers() {
   // clang-format off
   std::map<std::string, ValueSerializer> serializer_functions = {
-    {Pose2Tag, [](gtsam::Key key, gtsam::Values& vals) { return io_values::serialize<gtsam::Pose2>(vals.at<gtsam::Pose2>(key)); }},
-    {Pose3Tag, [](gtsam::Key key, gtsam::Values& vals) { return io_values::serialize<gtsam::Pose3>(vals.at<gtsam::Pose3>(key)); }},
-    {Point2Tag, [](gtsam::Key key, gtsam::Values& vals) { return io_values::serialize<gtsam::Point2>(vals.at<gtsam::Point2>(key)); }},
-    {Point3Tag, [](gtsam::Key key, gtsam::Values& vals) { return io_values::serialize<gtsam::Point3>(vals.at<gtsam::Point3>(key)); }},
-    {VectorTag, [](gtsam::Key key, gtsam::Values& vals) { return io_values::serialize<gtsam::Vector>(vals.at<gtsam::Vector>(key)); }},
-    {ScalarTag, [](gtsam::Key key, gtsam::Values& vals) { return io_values::serialize<double>(vals.at<double>(key)); }},
+    {Pose2Tag,   [](gtsam::Key key, gtsam::Values& vals) { return io_values::serialize<gtsam::Pose2>(vals.at<gtsam::Pose2>(key)); }},
+    {Pose3Tag,   [](gtsam::Key key, gtsam::Values& vals) { return io_values::serialize<gtsam::Pose3>(vals.at<gtsam::Pose3>(key)); }},
+    {Point2Tag,  [](gtsam::Key key, gtsam::Values& vals) { return io_values::serialize<gtsam::Point2>(vals.at<gtsam::Point2>(key)); }},
+    {Point3Tag,  [](gtsam::Key key, gtsam::Values& vals) { return io_values::serialize<gtsam::Point3>(vals.at<gtsam::Point3>(key)); }},
+    {VectorTag,  [](gtsam::Key key, gtsam::Values& vals) { return io_values::serialize<gtsam::Vector>(vals.at<gtsam::Vector>(key)); }},
+    {ScalarTag,  [](gtsam::Key key, gtsam::Values& vals) { return io_values::serialize<double>(vals.at<double>(key)); }},
+    {IMUBiasTag, [](gtsam::Key key, gtsam::Values& vals) { return io_values::serialize<gtsam::imuBias::ConstantBias>(vals.at<gtsam::imuBias::ConstantBias>(key)); }},
   };
   // clang-format on
   return serializer_functions;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Setup gtest
+include(FetchContent)
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG        origin/main
+)
+option(INSTALL_GTEST OFF)
+FetchContent_MakeAvailable(googletest)
+enable_testing() # enable ctest
+
+# Make test target
+file(GLOB_RECURSE tests_srcs *.cpp)
+add_executable(jrl-tests ${tests_srcs})
+target_link_libraries(jrl-tests PUBLIC jrl gtsam gtest)
+add_test(NAME jrl-tests COMMAND jrl-tests)
+
+# Make runnable from "make check" or "make test"
+add_custom_target(check COMMAND jrl-tests)
+add_custom_target(test COMMAND jrl-tests)

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,0 +1,6 @@
+#include "gtest/gtest.h"
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/test_CombinedIMUFactor.cpp
+++ b/tests/test_CombinedIMUFactor.cpp
@@ -17,7 +17,7 @@ using gtsam::symbol_shorthand::B;
   EXPECT_TRUE(M_actual.isApprox(M_expected, 1e-6)) << "  Actual:\n" << M_actual << "\nExpected:\n" << M_expected
 
 
-TEST(CombinedIMU, WriteParse){
+TEST(Factor, CombinedIMU){
     // Setup nonstandard params
     boost::shared_ptr<gtsam::PreintegrationCombinedParams> params = gtsam::PreintegrationCombinedParams::MakeSharedU();
     params->accelerometerCovariance = Eigen::Matrix3d::Identity() * 2;

--- a/tests/test_CombinedIMUFactor.cpp
+++ b/tests/test_CombinedIMUFactor.cpp
@@ -24,9 +24,12 @@ TEST(CombinedIMU, WriteParse){
     params->gyroscopeCovariance = Eigen::Matrix3d::Identity() * 3;
     params->biasAccCovariance = Eigen::Matrix3d::Identity() * 4;
     params->biasOmegaCovariance = Eigen::Matrix3d::Identity() * 5;
+    params->biasAccOmegaInt = Eigen::Matrix<double,6,6>::Identity() * 6;
+    params->integrationCovariance = Eigen::Matrix3d::Identity() * 7;
 
     // Setup measurements
-    gtsam::PreintegratedCombinedMeasurements pim(params);
+    gtsam::imuBias::ConstantBias b(gtsam::Vector3::Constant(6), gtsam::Vector3::Constant(7));
+    gtsam::PreintegratedCombinedMeasurements pim(params, b);
     gtsam::Vector3 accel{1,2,3};
     gtsam::Vector3 omega{4,5,6};
     double dt = 0.1;
@@ -55,8 +58,7 @@ TEST(CombinedIMU, WriteParse){
 
     // Check to make sure they're the same
     EXPECT_TRUE(write_factor.equals(*read_factor));
-    gtsam::Pose3 x;
-    gtsam::Vector3 v;
-    gtsam::imuBias::ConstantBias b;
+    gtsam::Pose3 x = gtsam::Pose3::identity();
+    gtsam::Vector3 v(1,2,3);
     EXPECT_MATRICES_EQ(write_factor.evaluateError(x, v, x, v, b, b), read_factor->evaluateError(x, v, x, v, b, b));
 }

--- a/tests/test_CombinedIMUFactor.cpp
+++ b/tests/test_CombinedIMUFactor.cpp
@@ -1,0 +1,62 @@
+#include <gtsam/geometry/Cal3_S2Stereo.h>
+#include <gtsam/geometry/StereoPoint2.h>
+#include <gtsam/slam/StereoFactor.h>
+#include <jrl/Dataset.h>
+#include <jrl/DatasetBuilder.h>
+#include <jrl/Parser.h>
+#include <jrl/Writer.h>
+#include <jrl/IOMeasurements.h>
+
+#include "gtest/gtest.h"
+
+using gtsam::symbol_shorthand::X;
+using gtsam::symbol_shorthand::V;
+using gtsam::symbol_shorthand::B;
+
+#define EXPECT_MATRICES_EQ(M_actual, M_expected) \
+  EXPECT_TRUE(M_actual.isApprox(M_expected, 1e-6)) << "  Actual:\n" << M_actual << "\nExpected:\n" << M_expected
+
+
+TEST(CombinedIMU, WriteParse){
+    // Setup nonstandard params
+    boost::shared_ptr<gtsam::PreintegrationCombinedParams> params = gtsam::PreintegrationCombinedParams::MakeSharedU();
+    params->accelerometerCovariance = Eigen::Matrix3d::Identity() * 2;
+    params->gyroscopeCovariance = Eigen::Matrix3d::Identity() * 3;
+    params->biasAccCovariance = Eigen::Matrix3d::Identity() * 4;
+    params->biasOmegaCovariance = Eigen::Matrix3d::Identity() * 5;
+
+    // Setup measurements
+    gtsam::PreintegratedCombinedMeasurements pim(params);
+    gtsam::Vector3 accel{1,2,3};
+    gtsam::Vector3 omega{4,5,6};
+    double dt = 0.1;
+    pim.integrateMeasurement(accel, omega, dt);
+    pim.integrateMeasurement(accel, omega, dt);
+
+    // Setup factor
+    int i = 0;
+    int j = 1;
+    gtsam::CombinedImuFactor write_factor(X(i), V(i), X(j), V(j), B(i), B(j), pim);
+
+    // Save it 
+    gtsam::NonlinearFactorGraph graph;
+    graph.push_back(write_factor);
+
+    jrl::DatasetBuilder builder("test", {'a'});
+    builder.addEntry('a', 0, graph, {jrl::CombinedIMUTag});
+
+    jrl::Writer writer;
+    writer.writeDataset(builder.build(), "combined_imu.jrl");
+
+    // Load it back in!
+    jrl::Parser parser;
+    jrl::Dataset dataset = parser.parseDataset("combined_imu.jrl");
+    gtsam::CombinedImuFactor::shared_ptr read_factor = boost::dynamic_pointer_cast<gtsam::CombinedImuFactor>(dataset.factorGraph()[0]);
+
+    // Check to make sure they're the same
+    EXPECT_TRUE(write_factor.equals(*read_factor));
+    gtsam::Pose3 x;
+    gtsam::Vector3 v;
+    gtsam::imuBias::ConstantBias b;
+    EXPECT_MATRICES_EQ(write_factor.evaluateError(x, v, x, v, b, b), read_factor->evaluateError(x, v, x, v, b, b));
+}

--- a/tests/test_CombinedIMUFactor.cpp
+++ b/tests/test_CombinedIMUFactor.cpp
@@ -58,7 +58,7 @@ TEST(Factor, CombinedIMU){
 
     // Check to make sure they're the same
     EXPECT_TRUE(write_factor.equals(*read_factor));
-    gtsam::Pose3 x = gtsam::Pose3::identity();
+    gtsam::Pose3 x = gtsam::Pose3::Identity();
     gtsam::Vector3 v(1,2,3);
     EXPECT_MATRICES_EQ(write_factor.evaluateError(x, v, x, v, b, b), read_factor->evaluateError(x, v, x, v, b, b));
 }

--- a/tests/test_IMUBias.cpp
+++ b/tests/test_IMUBias.cpp
@@ -36,10 +36,10 @@ TEST(Value, IMUBias){
     writer.writeDataset(builder.build(), "imu_bias.jrl");
 
     // Load it back in!
-    // jrl::Parser parser;
-    // jrl::Dataset dataset = parser.parseDataset("imu_bias.jrl");
-    // gtsam::imuBias::ConstantBias b_read = dataset.initialization().at<gtsam::imuBias::ConstantBias>(B(0));
+    jrl::Parser parser;
+    jrl::Dataset dataset = parser.parseDataset("imu_bias.jrl");
+    gtsam::imuBias::ConstantBias b_read = dataset.initialization('a').at<gtsam::imuBias::ConstantBias>(B(0));
 
     // Check to make sure they're the same
-    // EXPECT_MATRICES_EQ(b.vector(), b_read.vector());
+    EXPECT_MATRICES_EQ(b.vector(), b_read.vector());
 }

--- a/tests/test_IMUBias.cpp
+++ b/tests/test_IMUBias.cpp
@@ -1,0 +1,45 @@
+#include <gtsam/geometry/Cal3_S2Stereo.h>
+#include <gtsam/geometry/StereoPoint2.h>
+#include <gtsam/slam/StereoFactor.h>
+#include <jrl/Dataset.h>
+#include <jrl/DatasetBuilder.h>
+#include <jrl/Parser.h>
+#include <jrl/Writer.h>
+#include <jrl/IOMeasurements.h>
+
+#include "gtest/gtest.h"
+
+using gtsam::symbol_shorthand::X;
+using gtsam::symbol_shorthand::V;
+using gtsam::symbol_shorthand::B;
+
+#define EXPECT_MATRICES_EQ(M_actual, M_expected) \
+  EXPECT_TRUE(M_actual.isApprox(M_expected, 1e-6)) << "  Actual:\n" << M_actual << "\nExpected:\n" << M_expected
+
+
+TEST(Value, IMUBias){
+    // Item to save
+    gtsam::imuBias::ConstantBias b(gtsam::Vector3::Constant(6), gtsam::Vector3::Constant(7));
+
+    // Save it 
+    gtsam::NonlinearFactorGraph graph;
+    gtsam::Values theta;
+    jrl::ValueTypes types;
+
+    theta.insert(B(0), b);
+    types[B(0)] = jrl::IMUBiasTag;
+
+    jrl::DatasetBuilder builder("test", {'a'});
+    builder.addEntry('a', 0, graph, {}, jrl::TypedValues(theta, types));
+
+    jrl::Writer writer;
+    writer.writeDataset(builder.build(), "imu_bias.jrl");
+
+    // Load it back in!
+    // jrl::Parser parser;
+    // jrl::Dataset dataset = parser.parseDataset("imu_bias.jrl");
+    // gtsam::imuBias::ConstantBias b_read = dataset.initialization().at<gtsam::imuBias::ConstantBias>(B(0));
+
+    // Check to make sure they're the same
+    // EXPECT_MATRICES_EQ(b.vector(), b_read.vector());
+}

--- a/tests/test_StereoFactor.cpp
+++ b/tests/test_StereoFactor.cpp
@@ -18,7 +18,7 @@ using gtsam::symbol_shorthand::L;
 
 typedef typename gtsam::GenericStereoFactor<gtsam::Pose3, gtsam::Point3> StereoFactor;
 
-TEST(StereoFactor, WriteParse){
+TEST(Factor, StereoFactor){
     // Make everything for the stereo factor
     gtsam::Cal3_S2Stereo::shared_ptr m_stereoCalibration = boost::make_shared<gtsam::Cal3_S2Stereo>(6, 8, 0.0, 3, 4, 0.1);
     auto m_stereoNoiseModel = gtsam::noiseModel::Isotropic::Sigma(3, 1);

--- a/tests/test_StereoFactor.cpp
+++ b/tests/test_StereoFactor.cpp
@@ -1,0 +1,52 @@
+#include <gtsam/geometry/Cal3_S2Stereo.h>
+#include <gtsam/geometry/StereoPoint2.h>
+#include <gtsam/slam/StereoFactor.h>
+#include <jrl/Dataset.h>
+#include <jrl/DatasetBuilder.h>
+#include <jrl/Parser.h>
+#include <jrl/Writer.h>
+#include <jrl/IOMeasurements.h>
+
+#include "gtest/gtest.h"
+
+using gtsam::symbol_shorthand::X;
+using gtsam::symbol_shorthand::L;
+
+#define EXPECT_MATRICES_EQ(M_actual, M_expected) \
+  EXPECT_TRUE(M_actual.isApprox(M_expected, 1e-6)) << "  Actual:\n" << M_actual << "\nExpected:\n" << M_expected
+
+
+typedef typename gtsam::GenericStereoFactor<gtsam::Pose3, gtsam::Point3> StereoFactor;
+
+TEST(StereoFactor, WriteParse){
+    // Make everything for the stereo factor
+    gtsam::Cal3_S2Stereo::shared_ptr m_stereoCalibration = boost::make_shared<gtsam::Cal3_S2Stereo>(6, 8, 0.0, 3, 4, 0.1);
+    auto m_stereoNoiseModel = gtsam::noiseModel::Isotropic::Sigma(3, 1);
+    gtsam::Symbol landmarkKey = L(0);
+    gtsam::Symbol poseKey = X(0);
+    gtsam::StereoCamera camera(gtsam::Pose3(), m_stereoCalibration);
+    gtsam::StereoPoint2 stereoPoint(1, 2, 3);
+    gtsam::Point3 estimate = camera.backproject(stereoPoint);
+
+    StereoFactor write_factor(stereoPoint, m_stereoNoiseModel, poseKey, landmarkKey, m_stereoCalibration);
+
+    // Save it 
+    gtsam::NonlinearFactorGraph graph;
+    graph.push_back(write_factor);
+
+    jrl::DatasetBuilder builder("test", {'a'});
+    builder.addEntry('a', 0, graph, {jrl::StereoFactorPose3Point3Tag});
+
+    jrl::Writer writer;
+    writer.writeDataset(builder.build(), "stereo.jrl");
+
+    // Load it back in!
+    jrl::Parser parser;
+    jrl::Dataset dataset = parser.parseDataset("stereo.jrl");
+    StereoFactor::shared_ptr read_factor = boost::dynamic_pointer_cast<StereoFactor>(dataset.factorGraph()[0]);
+
+    gtsam::Pose3 x0;
+    gtsam::Point3 l0;
+    EXPECT_TRUE(write_factor.equals(*read_factor));
+    EXPECT_MATRICES_EQ(write_factor.evaluateError(x0, l0), read_factor->evaluateError(x0, l0));
+}

--- a/tests/test_StereoFactor.cpp
+++ b/tests/test_StereoFactor.cpp
@@ -46,7 +46,7 @@ TEST(Factor, StereoFactor){
     StereoFactor::shared_ptr read_factor = boost::dynamic_pointer_cast<StereoFactor>(dataset.factorGraph()[0]);
 
 
-    gtsam::Pose3 x0 = gtsam::Pose3::identity();
+    gtsam::Pose3 x0 = gtsam::Pose3::Identity();
     gtsam::Point3 l0(3, 2, 1);
     EXPECT_TRUE(write_factor.equals(*read_factor));
     EXPECT_MATRICES_EQ(write_factor.evaluateError(x0, l0), read_factor->evaluateError(x0, l0));

--- a/tests/test_StereoFactor.cpp
+++ b/tests/test_StereoFactor.cpp
@@ -45,8 +45,9 @@ TEST(StereoFactor, WriteParse){
     jrl::Dataset dataset = parser.parseDataset("stereo.jrl");
     StereoFactor::shared_ptr read_factor = boost::dynamic_pointer_cast<StereoFactor>(dataset.factorGraph()[0]);
 
-    gtsam::Pose3 x0;
-    gtsam::Point3 l0;
+
+    gtsam::Pose3 x0 = gtsam::Pose3::identity();
+    gtsam::Point3 l0(3, 2, 1);
     EXPECT_TRUE(write_factor.equals(*read_factor));
     EXPECT_MATRICES_EQ(write_factor.evaluateError(x0, l0), read_factor->evaluateError(x0, l0));
 }


### PR DESCRIPTION
First off, I apologize for the size of the pull request. I didn't realize how many changes/additions I made until I was done;) And no rush to get to this, so take your time.

This pull request should add the following functionality to the parser/serializer:
- gtsam::imuBias::ConstantBias
- gtsam::StereoPoint2
- gtsam::Cal3_S2 camera calibration
- gtsam::CombinedImuFactor
- gtsam::GenericStereoFactor<Pose, Landmark>
- general Eigen::Matrix types

Additionally I added
- Extra interface for adding ground truth / initialization to the DatasetBuilder. As these aren't saved in an iterative fashion, a unified method to add them seemed to make sense.
-  gtest and a testing framework. Gtest will be downloaded during configure time and tests can be built and ran using `make test` or `make check`. (We could also optionally add a CI via a github action if you're interested to test on pushes and/or pull requests). Currently there's just a couple tests for the factors I was working on.

Some design topics that I could use some feedback on:
- To support these factors, gtsam needed some extra getters / constructors ([See here](https://github.com/borglab/gtsam/compare/develop...contagon:gtsam:preint_stereo_helpers)), which I imagine will need to be merged into gtsam 4.2.X... which doesn't use boost. Do you want to switch jrl over to using std instead of boost for future gstam versions?
- Wasn't sure if Cal3_S2 should be in IOValues or IOMeasurements... it ended up in IOMeasurements next to parseMatrix/parseCovariance. Happy to switch it though.
- Speaking of, Matrix/Covariance is the only object that isn't serialized with a type tag, should we change that? Didn't want to off hand as it'll be a breaking change.
