### PR TITLE
Misc Optimizations

### DIFF
--- a/include/jrl/IOValues.h
+++ b/include/jrl/IOValues.h
@@ -29,13 +29,13 @@ namespace io_values {
  * @param accum: The values to which we add the value
 */
 template <typename VALUE>
-void valueAccumulator(std::function<VALUE(json)> parser, json input_json, gtsam::Key key, gtsam::Values& accum) {
+void valueAccumulator(std::function<VALUE(const json&)> parser, const json& input_json, gtsam::Key key, gtsam::Values& accum) {
   accum.insert(key, parser(input_json));
 }
 
 /**********************************************************************************************************************/
 template <typename T>
-T parse(json input_json) {  // Base Parse function for builtins. Specialization provided for all iovalues
+T parse(const json& input_json) {  // Base Parse function for builtins. Specialization provided for all iovalues
   return input_json["value"].get<T>();
 }
 
@@ -52,56 +52,56 @@ json serialize(T obj) {  // Base Parse function for builtins. Specialization pro
 /**********************************************************************************************************************/
 // Rot2
 template <>
-gtsam::Rot2 parse<gtsam::Rot2>(json input_json);
+gtsam::Rot2 parse<gtsam::Rot2>(const json& input_json);
 template <>
 json serialize<gtsam::Rot2>(gtsam::Rot2 pose);
 
 /**********************************************************************************************************************/
 // POSE2
 template <>
-gtsam::Pose2 parse<gtsam::Pose2>(json input_json);
+gtsam::Pose2 parse<gtsam::Pose2>(const json& input_json);
 template <>
 json serialize<gtsam::Pose2>(gtsam::Pose2 pose);
 
 /**********************************************************************************************************************/
-// Rot2
+// Rot3
 template <>
-gtsam::Rot3 parse<gtsam::Rot3>(json input_json);
+gtsam::Rot3 parse<gtsam::Rot3>(const json& input_json);
 template <>
 json serialize<gtsam::Rot3>(gtsam::Rot3 pose);
 
 /**********************************************************************************************************************/
 // POSE3
 template <>
-gtsam::Pose3 parse<gtsam::Pose3>(json input_json);
+gtsam::Pose3 parse<gtsam::Pose3>(const json& input_json);
 template <>
 json serialize<gtsam::Pose3>(gtsam::Pose3 pose);
 
 /**********************************************************************************************************************/
 // VECTOR
 template <>
-gtsam::Vector parse<gtsam::Vector>(json input_json);
+gtsam::Vector parse<gtsam::Vector>(const json& input_json);
 template <>
 json serialize<gtsam::Vector>(gtsam::Vector vec);
 
 /**********************************************************************************************************************/
 // Point2
 template <>
-gtsam::Point2 parse<gtsam::Point2>(json input_json);
+gtsam::Point2 parse<gtsam::Point2>(const json& input_json);
 template <>
 json serialize<gtsam::Point2>(gtsam::Point2 point);
 
 /**********************************************************************************************************************/
 // Point3
 template <>
-gtsam::Point3 parse<gtsam::Point3>(json input_json);
+gtsam::Point3 parse<gtsam::Point3>(const json& input_json);
 template <>
 json serialize<gtsam::Point3>(gtsam::Point3 point);
 
 /**********************************************************************************************************************/
 // Unit3
 template <>
-gtsam::Unit3 parse<gtsam::Unit3>(json input_json);
+gtsam::Unit3 parse<gtsam::Unit3>(const json& input_json);
 template <>
 json serialize<gtsam::Unit3>(gtsam::Unit3 point);
 
@@ -109,7 +109,7 @@ json serialize<gtsam::Unit3>(gtsam::Unit3 point);
 // BearingRange Need special treatment because c++ does not allow function partial specialization
 template <typename A1, typename A2, typename B = typename gtsam::Bearing<A1, A2>::result_type,
           typename R = typename gtsam::Range<A1, A2>::result_type>
-gtsam::BearingRange<A1, A2> parseBearingRange(json input_json) {
+gtsam::BearingRange<A1, A2> parseBearingRange(const json& input_json) {
   B bearing = parse<B>(input_json["bearing"]);
   R range = parse<R>(input_json["range"]);
   return gtsam::BearingRange<A1, A2>(bearing, range);
@@ -120,8 +120,8 @@ template <typename A1, typename A2, typename B = typename gtsam::Bearing<A1, A2>
 json serializeBearingRange(gtsam::BearingRange<A1, A2> bearingrange) {
   json output;
   output["type"] = BearingRangeTag;
-  output["bearing"] = serialize<B>(bearingrange.bearing());
-  output["range"] = serialize<R>(bearingrange.range());
+  output["bearing"] = io_values::serialize<B>(bearingrange.bearing());
+  output["range"] = io_values::serialize<R>(bearingrange.range());
   return output;
 }
 

--- a/include/jrl/IOValues.h
+++ b/include/jrl/IOValues.h
@@ -120,8 +120,8 @@ template <typename A1, typename A2, typename B = typename gtsam::Bearing<A1, A2>
 json serializeBearingRange(gtsam::BearingRange<A1, A2> bearingrange) {
   json output;
   output["type"] = BearingRangeTag;
-  output["bearing"] = io_values::serialize<B>(bearingrange.bearing());
-  output["range"] = io_values::serialize<R>(bearingrange.range());
+  output["bearing"] = serialize<B>(bearingrange.bearing());
+  output["range"] = serialize<R>(bearingrange.range());
   return output;
 }
 

--- a/include/jrl/Parser.h
+++ b/include/jrl/Parser.h
@@ -34,13 +34,13 @@ class Parser {
    *  @param values_json Input JSON containing the serialized values
    *  @return Parsed Values as GTSAM types
    **/
-  TypedValues parseValues(json values_json) const;
+  TypedValues parseValues(const json& values_json) const;
 
   /** @brief Parses all measurements using the loaded measurement parsers
    *  @param measurements_json Input JSON containing the serialized measurement entries
    *  @return Parsed measurement entries
    **/
-  std::vector<Entry> parseMeasurements(json measurements_json) const;
+  std::vector<Entry> parseMeasurements(const json& measurements_json) const;
 
   /** @brief Reads arbitrary JSON from file
    * @param input_file_name: The file from which to read the json

--- a/src/IOValues.cpp
+++ b/src/IOValues.cpp
@@ -9,7 +9,7 @@ namespace io_values {
 /**********************************************************************************************************************/
 // Rot2
 template <>
-gtsam::Rot2 parse<gtsam::Rot2>(json input_json) {
+gtsam::Rot2 parse<gtsam::Rot2>(const json& input_json) {
   double theta = input_json["theta"].get<double>();
   return gtsam::Rot2(theta);
 }
@@ -25,7 +25,7 @@ json serialize<gtsam::Rot2>(gtsam::Rot2 rot) {
 /**********************************************************************************************************************/
 // POSE2
 template <>
-gtsam::Pose2 parse<gtsam::Pose2>(json input_json) {
+gtsam::Pose2 parse<gtsam::Pose2>(const json& input_json) {
   double x = input_json["x"].get<double>();
   double y = input_json["y"].get<double>();
   double theta = input_json["theta"].get<double>();
@@ -45,7 +45,7 @@ json serialize<gtsam::Pose2>(gtsam::Pose2 pose) {
 /**********************************************************************************************************************/
 // Rot3
 template <>
-gtsam::Rot3 parse<gtsam::Rot3>(json input_json) {
+gtsam::Rot3 parse<gtsam::Rot3>(const json& input_json) {
   std::vector<double> q = input_json["rotation"].get<std::vector<double>>();
   return gtsam::Rot3::Quaternion(q[0], q[1], q[2], q[3]);
 }
@@ -55,14 +55,14 @@ json serialize<gtsam::Rot3>(gtsam::Rot3 rot) {
   json output;
   output["type"] = Rot3Tag;
   gtsam::Vector q = rot.quaternion();
-  output["rotation"] = {q(0), q(1), q(2), q(3)};
+  output["r"] = {q(0), q(1), q(2), q(3)};
   return output;
 }
 
 /**********************************************************************************************************************/
 // POSE3
 template <>
-gtsam::Pose3 parse<gtsam::Pose3>(json input_json) {
+gtsam::Pose3 parse<gtsam::Pose3>(const json& input_json) {
   std::vector<double> t = input_json["translation"].get<std::vector<double>>();
   gtsam::Vector3 translation(t.data());
   std::vector<double> q = input_json["rotation"].get<std::vector<double>>();
@@ -83,7 +83,7 @@ json serialize<gtsam::Pose3>(gtsam::Pose3 pose) {
 /**********************************************************************************************************************/
 // VECTOR
 template <>
-gtsam::Vector parse<gtsam::Vector>(json input_json) {
+gtsam::Vector parse<gtsam::Vector>(const json& input_json) {
   std::vector<double> stdvec = input_json["data"].get<std::vector<double>>();
   gtsam::Vector eigvec = Eigen::Map<gtsam::Vector>(stdvec.data(), stdvec.size());
   return eigvec;
@@ -100,7 +100,7 @@ json serialize<gtsam::Vector>(gtsam::Vector vec) {
 /**********************************************************************************************************************/
 // Point2
 template <>
-gtsam::Point2 parse<gtsam::Point2>(json input_json) {
+gtsam::Point2 parse<gtsam::Point2>(const json& input_json) {
   double x = input_json["x"].get<double>();
   double y = input_json["y"].get<double>();
   return gtsam::Point2(x, y);
@@ -118,7 +118,7 @@ json serialize<gtsam::Point2>(gtsam::Point2 point) {
 /**********************************************************************************************************************/
 // Point3
 template <>
-gtsam::Point3 parse<gtsam::Point3>(json input_json) {
+gtsam::Point3 parse<gtsam::Point3>(const json& input_json) {
   double x = input_json["x"].get<double>();
   double y = input_json["y"].get<double>();
   double z = input_json["z"].get<double>();
@@ -139,7 +139,7 @@ json serialize<gtsam::Point3>(gtsam::Point3 point) {
 /**********************************************************************************************************************/
 // Unit3
 template <>
-gtsam::Unit3 parse<gtsam::Unit3>(json input_json) {
+gtsam::Unit3 parse<gtsam::Unit3>(const json& input_json) {
   double i = input_json["i"].get<double>();
   double j = input_json["j"].get<double>();
   double k = input_json["k"].get<double>();

--- a/src/IOValues.cpp
+++ b/src/IOValues.cpp
@@ -55,7 +55,7 @@ json serialize<gtsam::Rot3>(gtsam::Rot3 rot) {
   json output;
   output["type"] = Rot3Tag;
   gtsam::Vector q = rot.quaternion();
-  output["r"] = {q(0), q(1), q(2), q(3)};
+  output["rotation"] = {q(0), q(1), q(2), q(3)};
   return output;
 }
 

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -23,12 +23,12 @@ Parser::Parser() {
 std::map<std::string, ValueParser> Parser::loadDefaultValueAccumulators() {
   // clang-format off
   std::map<std::string, ValueParser> parser_functions = {
-      {Pose2Tag,  [](json input, gtsam::Key key, gtsam::Values& accum) { return valueAccumulator<gtsam::Pose2>(&parse<gtsam::Pose2>, input, key, accum); }},
-      {Pose3Tag,  [](json input, gtsam::Key key, gtsam::Values& accum) { return valueAccumulator<gtsam::Pose3>(&parse<gtsam::Pose3>, input, key, accum); }},
-      {Point2Tag, [](json input, gtsam::Key key, gtsam::Values& accum) { return valueAccumulator<gtsam::Point2>(&parse<gtsam::Point2>, input, key, accum); }},
-      {Point3Tag, [](json input, gtsam::Key key, gtsam::Values& accum) { return valueAccumulator<gtsam::Point3>(&parse<gtsam::Point3>, input, key, accum); }},
-      {VectorTag, [](json input, gtsam::Key key, gtsam::Values& accum) { return valueAccumulator<gtsam::Vector>(&parse<gtsam::Vector>, input, key, accum); }},
-      {ScalarTag, [](json input, gtsam::Key key, gtsam::Values& accum) { return valueAccumulator<double>(&parse<double>, input, key, accum); }},
+      {Pose2Tag,        [](const json& input, gtsam::Key key, gtsam::Values& accum) { return valueAccumulator<gtsam::Pose2>(&parse<gtsam::Pose2>, input, key, accum); }},
+      {Pose3Tag,        [](const json& input, gtsam::Key key, gtsam::Values& accum) { return valueAccumulator<gtsam::Pose3>(&parse<gtsam::Pose3>, input, key, accum); }},
+      {Point2Tag,       [](const json& input, gtsam::Key key, gtsam::Values& accum) { return valueAccumulator<gtsam::Point2>(&parse<gtsam::Point2>, input, key, accum); }},
+      {Point3Tag,       [](const json& input, gtsam::Key key, gtsam::Values& accum) { return valueAccumulator<gtsam::Point3>(&parse<gtsam::Point3>, input, key, accum); }},
+      {VectorTag,       [](const json& input, gtsam::Key key, gtsam::Values& accum) { return valueAccumulator<gtsam::Vector>(&parse<gtsam::Vector>, input, key, accum); }},
+      {ScalarTag,       [](const json& input, gtsam::Key key, gtsam::Values& accum) { return valueAccumulator<double>(&parse<double>, input, key, accum); }},
   };
   // clang-format on
   return parser_functions;
@@ -38,29 +38,29 @@ std::map<std::string, ValueParser> Parser::loadDefaultValueAccumulators() {
 std::map<std::string, MeasurementParser> Parser::loadDefaultMeasurementParsers() {
   // clang-format off
   std::map<std::string, MeasurementParser> parser_functions = {
-      {PriorFactorPose2Tag,         [](json input) { return parsePrior<gtsam::Pose2>(&parse<gtsam::Pose2>, input); }},
-      {PriorFactorPose3Tag,         [](json input) { return parsePrior<gtsam::Pose3>(&parse<gtsam::Pose3>, input); }},
-      {BetweenFactorPose2Tag,       [](json input) { return parseNoiseModel2<gtsam::Pose2, gtsam::BetweenFactor<gtsam::Pose2>>(&parse<gtsam::Pose2>, input); }},
-      {BetweenFactorPose3Tag,       [](json input) { return parseNoiseModel2<gtsam::Pose3, gtsam::BetweenFactor<gtsam::Pose3>>(&parse<gtsam::Pose3>, input); }},
-      {RangeFactorPose2Tag,         [](json input) { return parseNoiseModel2<double, gtsam::RangeFactor<gtsam::Pose2>>(&parse<double>, input); }},
-      {RangeFactorPose3Tag,         [](json input) { return parseNoiseModel2<double, gtsam::RangeFactor<gtsam::Pose3>>(&parse<double>, input); }},
-      {RangeFactor2DTag,            [](json input) { return parseNoiseModel2<double, gtsam::RangeFactor<gtsam::Pose2, gtsam::Point2>>(&parse<double>, input); }},
-      {RangeFactor3DTag,            [](json input) { return parseNoiseModel2<double, gtsam::RangeFactor<gtsam::Pose3, gtsam::Point3>>(&parse<double>, input); }},
-      {BearingRangeFactorPose2Tag,  [](json input) { return parseNoiseModel2<gtsam::BearingRange<gtsam::Pose2, gtsam::Pose2>, gtsam::BearingRangeFactor<gtsam::Pose2, gtsam::Pose2>>(&parseBearingRange<gtsam::Pose2, gtsam::Pose2>, input); }},
-      {BearingRangeFactorPose3Tag,  [](json input) { return parseNoiseModel2<gtsam::BearingRange<gtsam::Pose3, gtsam::Pose3>, gtsam::BearingRangeFactor<gtsam::Pose3, gtsam::Pose3>>(&parseBearingRange<gtsam::Pose3, gtsam::Pose3>, input); }},
-      {BearingRangeFactor2DTag,     [](json input) { return parseNoiseModel2<gtsam::BearingRange<gtsam::Pose2, gtsam::Point2>, gtsam::BearingRangeFactor<gtsam::Pose2, gtsam::Point2>>(&parseBearingRange<gtsam::Pose2, gtsam::Point2>, input); }},
-      {BearingRangeFactor3DTag,     [](json input) { return parseNoiseModel2<gtsam::BearingRange<gtsam::Pose3, gtsam::Point3>, gtsam::BearingRangeFactor<gtsam::Pose3, gtsam::Point3>>(&parseBearingRange<gtsam::Pose3, gtsam::Point3>, input); }},
-      {PriorFactorPoint2Tag,        [](json input) { return parsePrior<gtsam::Point2>(&parse<gtsam::Point2>, input); }},
-      {PriorFactorPoint3Tag,        [](json input) { return parsePrior<gtsam::Point3>(&parse<gtsam::Point3>, input); }},
-      {BetweenFactorPoint2Tag,      [](json input) { return parseNoiseModel2<gtsam::Point2, gtsam::BetweenFactor<gtsam::Point2>>(&parse<gtsam::Point2>, input); }},
-      {BetweenFactorPoint3Tag,      [](json input) { return parseNoiseModel2<gtsam::Point3, gtsam::BetweenFactor<gtsam::Point3>>(&parse<gtsam::Point3>, input); }},
+      {PriorFactorPose2Tag,         [](const json& input) { return parsePrior<gtsam::Pose2>(&parse<gtsam::Pose2>, input); }},
+      {PriorFactorPose3Tag,         [](const json& input) { return parsePrior<gtsam::Pose3>(&parse<gtsam::Pose3>, input); }},
+      {BetweenFactorPose2Tag,       [](const json& input) { return parseNoiseModel2<gtsam::Pose2, gtsam::BetweenFactor<gtsam::Pose2>>(&parse<gtsam::Pose2>, input); }},
+      {BetweenFactorPose3Tag,       [](const json& input) { return parseNoiseModel2<gtsam::Pose3, gtsam::BetweenFactor<gtsam::Pose3>>(&parse<gtsam::Pose3>, input); }},
+      {RangeFactorPose2Tag,         [](const json& input) { return parseNoiseModel2<double, gtsam::RangeFactor<gtsam::Pose2>>(&parse<double>, input); }},
+      {RangeFactorPose3Tag,         [](const json& input) { return parseNoiseModel2<double, gtsam::RangeFactor<gtsam::Pose3>>(&parse<double>, input); }},
+      {RangeFactor2DTag,            [](const json& input) { return parseNoiseModel2<double, gtsam::RangeFactor<gtsam::Pose2, gtsam::Point2>>(&parse<double>, input); }},
+      {RangeFactor3DTag,            [](const json& input) { return parseNoiseModel2<double, gtsam::RangeFactor<gtsam::Pose3, gtsam::Point3>>(&parse<double>, input); }},
+      {BearingRangeFactorPose2Tag,  [](const json& input) { return parseNoiseModel2<gtsam::BearingRange<gtsam::Pose2, gtsam::Pose2>, gtsam::BearingRangeFactor<gtsam::Pose2, gtsam::Pose2>>(&parseBearingRange<gtsam::Pose2, gtsam::Pose2>, input); }},
+      {BearingRangeFactorPose3Tag,  [](const json& input) { return parseNoiseModel2<gtsam::BearingRange<gtsam::Pose3, gtsam::Pose3>, gtsam::BearingRangeFactor<gtsam::Pose3, gtsam::Pose3>>(&parseBearingRange<gtsam::Pose3, gtsam::Pose3>, input); }},
+      {BearingRangeFactor2DTag,     [](const json& input) { return parseNoiseModel2<gtsam::BearingRange<gtsam::Pose2, gtsam::Point2>, gtsam::BearingRangeFactor<gtsam::Pose2, gtsam::Point2>>(&parseBearingRange<gtsam::Pose2, gtsam::Point2>, input); }},
+      {BearingRangeFactor3DTag,     [](const json& input) { return parseNoiseModel2<gtsam::BearingRange<gtsam::Pose3, gtsam::Point3>, gtsam::BearingRangeFactor<gtsam::Pose3, gtsam::Point3>>(&parseBearingRange<gtsam::Pose3, gtsam::Point3>, input); }},
+      {PriorFactorPoint2Tag,        [](const json& input) { return parsePrior<gtsam::Point2>(&parse<gtsam::Point2>, input); }},
+      {PriorFactorPoint3Tag,        [](const json& input) { return parsePrior<gtsam::Point3>(&parse<gtsam::Point3>, input); }},
+      {BetweenFactorPoint2Tag,      [](const json& input) { return parseNoiseModel2<gtsam::Point2, gtsam::BetweenFactor<gtsam::Point2>>(&parse<gtsam::Point2>, input); }},
+      {BetweenFactorPoint3Tag,      [](const json& input) { return parseNoiseModel2<gtsam::Point3, gtsam::BetweenFactor<gtsam::Point3>>(&parse<gtsam::Point3>, input); }},
   };
   // clang-format on
   return parser_functions;
 }
 
 /**********************************************************************************************************************/
-TypedValues Parser::parseValues(json values_json) const {
+TypedValues Parser::parseValues(const json& values_json) const {
   gtsam::Values values;
   ValueTypes value_types;
   for (auto& value_element : values_json) {
@@ -73,7 +73,7 @@ TypedValues Parser::parseValues(json values_json) const {
 }
 
 /**********************************************************************************************************************/
-std::vector<Entry> Parser::parseMeasurements(json measurements_json) const {
+std::vector<Entry> Parser::parseMeasurements(const json& measurements_json) const {
   std::vector<Entry> measurements;
   for (auto& entry_element : measurements_json) {
     uint64_t stamp = entry_element["stamp"].get<uint64_t>();
@@ -89,7 +89,7 @@ std::vector<Entry> Parser::parseMeasurements(json measurements_json) const {
       potential_outlier_statuses =
           entry_element["potential_outlier_statuses"].get<std::map<gtsam::FactorIndex, bool>>();
     }
-    measurements.push_back(Entry(stamp, type_tags, entry_measurements, potential_outlier_statuses));
+    measurements.emplace_back(stamp, type_tags, entry_measurements, potential_outlier_statuses);
   }
   return measurements;
 }

--- a/src/Writer.cpp
+++ b/src/Writer.cpp
@@ -25,12 +25,12 @@ Writer::Writer() {
 std::map<std::string, ValueSerializer> Writer::loadDefaultValueSerializers() {
   // clang-format off
   std::map<std::string, ValueSerializer> serializer_functions = {
-    {Pose2Tag, [](gtsam::Key key, gtsam::Values& vals) { return serialize<gtsam::Pose2>(vals.at<gtsam::Pose2>(key)); }},
-    {Pose3Tag, [](gtsam::Key key, gtsam::Values& vals) { return serialize<gtsam::Pose3>(vals.at<gtsam::Pose3>(key)); }},
-    {Point2Tag, [](gtsam::Key key, gtsam::Values& vals) { return serialize<gtsam::Point2>(vals.at<gtsam::Point2>(key)); }},
-    {Point3Tag, [](gtsam::Key key, gtsam::Values& vals) { return serialize<gtsam::Point3>(vals.at<gtsam::Point3>(key)); }},
-    {VectorTag, [](gtsam::Key key, gtsam::Values& vals) { return serialize<gtsam::Vector>(vals.at<gtsam::Vector>(key)); }},
-    {ScalarTag, [](gtsam::Key key, gtsam::Values& vals) { return serialize<double>(vals.at<double>(key)); }},
+    {Pose2Tag,  [](gtsam::Key key, gtsam::Values& vals) { return io_values::serialize<gtsam::Pose2>(vals.at<gtsam::Pose2>(key)); }},
+    {Pose3Tag,  [](gtsam::Key key, gtsam::Values& vals) { return io_values::serialize<gtsam::Pose3>(vals.at<gtsam::Pose3>(key)); }},
+    {Point2Tag, [](gtsam::Key key, gtsam::Values& vals) { return io_values::serialize<gtsam::Point2>(vals.at<gtsam::Point2>(key)); }},
+    {Point3Tag, [](gtsam::Key key, gtsam::Values& vals) { return io_values::serialize<gtsam::Point3>(vals.at<gtsam::Point3>(key)); }},
+    {VectorTag, [](gtsam::Key key, gtsam::Values& vals) { return io_values::serialize<gtsam::Vector>(vals.at<gtsam::Vector>(key)); }},
+    {ScalarTag, [](gtsam::Key key, gtsam::Values& vals) { return io_values::serialize<double>(vals.at<double>(key)); }},
   };
   // clang-format on
   return serializer_functions;
@@ -83,7 +83,8 @@ json Writer::serializeMeasurements(std::vector<Entry> entries) const {
   for (auto& entry : entries) {
     json entry_obj;
     entry_obj["stamp"] = entry.stamp;
-    for (int i = 0; i < entry.measurements.nrFactors(); i++) {
+    size_t numFactors = entry.measurements.nrFactors();
+    for (int i = 0; i < numFactors; i++) {
       std::string measurement_type = entry.measurement_types[i];
       gtsam::NonlinearFactor::shared_ptr factor = entry.measurements.at(i);
       entry_obj["measurements"].push_back(measurement_serializers_.at(measurement_type)(factor));

--- a/src/Writer.cpp
+++ b/src/Writer.cpp
@@ -25,12 +25,12 @@ Writer::Writer() {
 std::map<std::string, ValueSerializer> Writer::loadDefaultValueSerializers() {
   // clang-format off
   std::map<std::string, ValueSerializer> serializer_functions = {
-    {Pose2Tag,  [](gtsam::Key key, gtsam::Values& vals) { return io_values::serialize<gtsam::Pose2>(vals.at<gtsam::Pose2>(key)); }},
-    {Pose3Tag,  [](gtsam::Key key, gtsam::Values& vals) { return io_values::serialize<gtsam::Pose3>(vals.at<gtsam::Pose3>(key)); }},
-    {Point2Tag, [](gtsam::Key key, gtsam::Values& vals) { return io_values::serialize<gtsam::Point2>(vals.at<gtsam::Point2>(key)); }},
-    {Point3Tag, [](gtsam::Key key, gtsam::Values& vals) { return io_values::serialize<gtsam::Point3>(vals.at<gtsam::Point3>(key)); }},
-    {VectorTag, [](gtsam::Key key, gtsam::Values& vals) { return io_values::serialize<gtsam::Vector>(vals.at<gtsam::Vector>(key)); }},
-    {ScalarTag, [](gtsam::Key key, gtsam::Values& vals) { return io_values::serialize<double>(vals.at<double>(key)); }},
+    {Pose2Tag,  [](gtsam::Key key, gtsam::Values& vals) { return serialize<gtsam::Pose2>(vals.at<gtsam::Pose2>(key)); }},
+    {Pose3Tag,  [](gtsam::Key key, gtsam::Values& vals) { return serialize<gtsam::Pose3>(vals.at<gtsam::Pose3>(key)); }},
+    {Point2Tag, [](gtsam::Key key, gtsam::Values& vals) { return serialize<gtsam::Point2>(vals.at<gtsam::Point2>(key)); }},
+    {Point3Tag, [](gtsam::Key key, gtsam::Values& vals) { return serialize<gtsam::Point3>(vals.at<gtsam::Point3>(key)); }},
+    {VectorTag, [](gtsam::Key key, gtsam::Values& vals) { return serialize<gtsam::Vector>(vals.at<gtsam::Vector>(key)); }},
+    {ScalarTag, [](gtsam::Key key, gtsam::Values& vals) { return serialize<double>(vals.at<double>(key)); }},
   };
   // clang-format on
   return serializer_functions;


### PR DESCRIPTION
This is a handful of optimization I did to try and speed up jrl. The most obvious one is passing the json object by const reference rather than by value. This seemed to have a small impact.

The largest impact I saw was actually caching the value of `nrFactors()` in Writer.cpp. This function has to iterate over the entire graph to count the non-null factors, so using it in the for loop was essentially O(n^2).

I also played around with trying to shrink the size of the resulting json via shrinking key names - ie "cov" instead of "covariance" and "t" instead of translation. This seemed to also have a decent sized positive impact (and shrunk file sizes), but isn't included here since it's a significant breaking change. Let me know if it's something we'd like to pursue however and I can push the changes.

If you're interested in optimizing further, moving from Nlohmann/json to RapidJson will likely [increase things significantly](https://github.com/miloyip/nativejson-benchmark), but might take a while to switch over.