### PR TITLE
Misc Convenience Helpers

### DIFF
--- a/include/jrl/Dataset.h
+++ b/include/jrl/Dataset.h
@@ -82,6 +82,11 @@ class Dataset {
    */
   gtsam::NonlinearFactorGraph factorGraph(const boost::optional<char>& robot_id = boost::none) const;
 
+
+/** @brief Returns the measurement types for a specific robot
+ * @param robot_id: The robot identifier for the measurement types to return. Not required for single robot dataset.
+ * @returns The specified robot's measurement types
+ */
   std::set<std::string> measurementTypes(const boost::optional<char>& robot_id = boost::none) const;
 
   /* HELPERS */

--- a/include/jrl/Dataset.h
+++ b/include/jrl/Dataset.h
@@ -37,6 +37,9 @@ class Dataset {
   /// @brief The set measurements made by each robot unordered in a factor graph
   std::map<char, gtsam::NonlinearFactorGraph> factor_graphs_;
 
+  /// @brief The type of measurements made by each robot in it's graph
+  std::map<char, std::set<std::string>> measurement_types_;
+
   /* INTERFACE */
  public:
   /** @brief Constructs a raw dataset
@@ -78,6 +81,8 @@ class Dataset {
    * @returns The specified robot's factor graph
    */
   gtsam::NonlinearFactorGraph factorGraph(const boost::optional<char>& robot_id = boost::none) const;
+
+  std::set<std::string> measurementTypes(const boost::optional<char>& robot_id = boost::none) const;
 
   /* HELPERS */
  private:

--- a/include/jrl/DatasetBuilder.h
+++ b/include/jrl/DatasetBuilder.h
@@ -34,6 +34,11 @@ class DatasetBuilder {
                 const boost::optional<TypedValues> initialization = boost::none,
                 const boost::optional<TypedValues> groundtruth = boost::none);
 
+  /// @brief 
+  void addGroundTruth(char robot, TypedValues groundtruth);
+
+  void addInitialization(char robot, TypedValues initialization);
+
   /// @brief Compiles a dataset from all the added entries
   Dataset build();
 };

--- a/include/jrl/DatasetBuilder.h
+++ b/include/jrl/DatasetBuilder.h
@@ -34,9 +34,10 @@ class DatasetBuilder {
                 const boost::optional<TypedValues> initialization = boost::none,
                 const boost::optional<TypedValues> groundtruth = boost::none);
 
-  /// @brief 
+  /// @brief Adds ground truth information for a single robot. Can be used incrementally or in bulk.
   void addGroundTruth(char robot, TypedValues groundtruth);
 
+  /// @brief Adds initial estimate information for a single robot. Can be used incrementally or in bulk.
   void addInitialization(char robot, TypedValues initialization);
 
   /// @brief Compiles a dataset from all the added entries

--- a/include/jrl/Parser.h
+++ b/include/jrl/Parser.h
@@ -30,18 +30,6 @@ class Parser {
   /// @return The default measurement parsers, which are loaded into measurement_parsers_ on initialization
   std::map<std::string, MeasurementParser> loadDefaultMeasurementParsers();
 
-  /** @brief Parses all values using the loaded value accumulators
-   *  @param values_json Input JSON containing the serialized values
-   *  @return Parsed Values as GTSAM types
-   **/
-  TypedValues parseValues(json values_json) const;
-
-  /** @brief Parses all measurements using the loaded measurement parsers
-   *  @param measurements_json Input JSON containing the serialized measurement entries
-   *  @return Parsed measurement entries
-   **/
-  std::vector<Entry> parseMeasurements(json measurements_json) const;
-
   /** @brief Reads arbitrary JSON from file
    * @param input_file_name: The file from which to read the json
    * @param decompress_from_cbor: if true indicates that input file is compressed with cbor
@@ -67,6 +55,18 @@ class Parser {
   /// @param decompress_from_cbor if true indicates that input files are compressed with cbor and must be decompressed
   /// before parsing
   MetricSummary parseMetricSummary(std::string metric_summary_file, bool decompress_from_cbor = false) const;
+
+  /** @brief Parses all values using the loaded value accumulators
+   *  @param values_json Input JSON containing the serialized values
+   *  @return Parsed Values as GTSAM types
+   **/
+  TypedValues parseValues(json values_json) const;
+
+  /** @brief Parses all measurements using the loaded measurement parsers
+   *  @param measurements_json Input JSON containing the serialized measurement entries
+   *  @return Parsed measurement entries
+   **/
+  std::vector<Entry> parseMeasurements(json measurements_json) const;
 
   /// @brief Add a custom value parser
   /// @param tag The tag to associate with the value

--- a/include/jrl/Parser.h
+++ b/include/jrl/Parser.h
@@ -68,9 +68,17 @@ class Parser {
   /// before parsing
   MetricSummary parseMetricSummary(std::string metric_summary_file, bool decompress_from_cbor = false) const;
 
-  // TODO
-  // void registerValueParser(std::string tag, ValueParser parser_fn);
-  // void registerMeasurementParser(std::string tag, MeasurementParser parser_fn);
+  /// @brief Add a custom value parser
+  /// @param tag The tag to associate with the value
+  /// @param parser_fn The parser function to parse the value
+  void registerValueParser(std::string tag, ValueParser parser_fn) { value_accumulators_[tag] = parser_fn; };
+
+  /// @brief Add a custom measurement parser
+  /// @param tag The tag to associate with the measurement
+  /// @param parser_fn The parser function to parse the measurement
+  void registerMeasurementParser(std::string tag, MeasurementParser parser_fn) {
+    measurement_parsers_[tag] = parser_fn;
+  };
 };
 
 }  // namespace jrl

--- a/include/jrl/Types.h
+++ b/include/jrl/Types.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <gtsam/nonlinear/NonlinearFactorGraph.h>
 #include <gtsam/nonlinear/Values.h>
 
 namespace jrl {
@@ -25,6 +26,12 @@ struct Entry {
         measurement_types(measurement_types),
         measurements(measurements),
         potential_outlier_statuses(potential_outlier_statuses) {}
+
+  // Remove all factors of a certain type
+  Entry remove(std::vector<std::string> remove_types);
+
+  // Only include factors of a certain type
+  Entry filter(std::vector<std::string> filter_types);
 };
 
 }  // namespace jrl

--- a/include/jrl/Types.h
+++ b/include/jrl/Types.h
@@ -5,7 +5,7 @@
 namespace jrl {
 
 typedef std::map<gtsam::Key, std::string> ValueTypes;
-typedef std::function<bool(std::string, gtsam::NonlinearFactor::shared_ptr&)> EntryPredicate;
+typedef std::function<bool(const std::string&, const gtsam::NonlinearFactor::shared_ptr&)> EntryPredicate;
 
 struct TypedValues {
   gtsam::Values values;
@@ -41,7 +41,7 @@ struct Entry {
   /// @brief Returns a new Entry with only the measurements that satisfy the predicate
   /// @param predicate Function that returns true if the measurement should be included
   /// @return New Entry with only the measurements that satisfy the predicate
-  Entry filtered(EntryPredicate predicate);
+  Entry filtered(EntryPredicate predicate) const;
 
 };
 

--- a/include/jrl/Types.h
+++ b/include/jrl/Types.h
@@ -5,6 +5,7 @@
 namespace jrl {
 
 typedef std::map<gtsam::Key, std::string> ValueTypes;
+typedef std::function<bool(std::string, gtsam::NonlinearFactor::shared_ptr&)> EntryPredicate;
 
 struct TypedValues {
   gtsam::Values values;
@@ -27,11 +28,21 @@ struct Entry {
         measurements(measurements),
         potential_outlier_statuses(potential_outlier_statuses) {}
 
-  // Remove all factors of a certain type
-  Entry remove(std::vector<std::string> remove_types);
+  /// @brief Helper to make predicate for filtering based on types
+  /// @param types List of jrl tags to keep
+  /// @return Predicate that returns true if the factor type is in the list of types
+  static EntryPredicate KeepTypes(std::vector<std::string> types);
 
-  // Only include factors of a certain type
-  Entry filter(std::vector<std::string> filter_types);
+  /// @brief Helper to make predicate for removing based on types
+  /// @param types List of jrl tags to remove
+  /// @return Predicate that returns true if the factor type is not the list of types
+  static EntryPredicate RemoveTypes(std::vector<std::string> types);
+
+  /// @brief Returns a new Entry with only the measurements that satisfy the predicate
+  /// @param predicate Function that returns true if the measurement should be included
+  /// @return New Entry with only the measurements that satisfy the predicate
+  Entry filtered(EntryPredicate predicate);
+
 };
 
 }  // namespace jrl

--- a/include/jrl/Types.h
+++ b/include/jrl/Types.h
@@ -5,7 +5,6 @@
 namespace jrl {
 
 typedef std::map<gtsam::Key, std::string> ValueTypes;
-typedef std::function<bool(const std::string&, const gtsam::NonlinearFactor::shared_ptr&)> EntryPredicate;
 
 struct TypedValues {
   gtsam::Values values;
@@ -21,6 +20,9 @@ struct Entry {
   gtsam::NonlinearFactorGraph measurements;
   std::map<gtsam::FactorIndex, bool> potential_outlier_statuses;
 
+  /// @brief Function that takes in a type and a factor and returns true if the factor should be kept
+  typedef std::function<bool(const std::string&, const gtsam::NonlinearFactor::shared_ptr&)> FilterPredicate;
+
   Entry(uint64_t stamp, std::vector<std::string> measurement_types, gtsam::NonlinearFactorGraph measurements,
         std::map<gtsam::FactorIndex, bool> potential_outlier_statuses = {})
       : stamp(stamp),
@@ -31,17 +33,17 @@ struct Entry {
   /// @brief Helper to make predicate for filtering based on types
   /// @param types List of jrl tags to keep
   /// @return Predicate that returns true if the factor type is in the list of types
-  static EntryPredicate KeepTypes(std::vector<std::string> types);
+  static FilterPredicate KeepTypes(std::vector<std::string> types);
 
   /// @brief Helper to make predicate for removing based on types
   /// @param types List of jrl tags to remove
   /// @return Predicate that returns true if the factor type is not the list of types
-  static EntryPredicate RemoveTypes(std::vector<std::string> types);
+  static FilterPredicate RemoveTypes(std::vector<std::string> types);
 
   /// @brief Returns a new Entry with only the measurements that satisfy the predicate
   /// @param predicate Function that returns true if the measurement should be included
   /// @return New Entry with only the measurements that satisfy the predicate
-  Entry filtered(EntryPredicate predicate) const;
+  Entry filtered(FilterPredicate predicate) const;
 
 };
 

--- a/include/jrl/Writer.h
+++ b/include/jrl/Writer.h
@@ -68,9 +68,19 @@ class Writer {
   void writeMetricSummary(MetricSummary metric_summary, std::string output_file_name,
                           bool compress_to_cbor = false) const;
 
-  // TODO
-  // void registerValueSerializer(std::string tag, ValueSerializer serializer_fn);
-  // void registerMeasurementParser(std::string tag, MeasurementSerializer serializer_fn);
+  /// @brief Register a custom value serializer
+  /// @param tag Tag to associate with the value
+  /// @param serializer_fn Serializer function to serialize the value
+  void registerValueSerializer(std::string tag, ValueSerializer serializer_fn) {
+    value_serializers_[tag] = serializer_fn;
+  };
+
+  /// @brief Register a custom measurement serializer
+  /// @param tag Tag to associate with the measurement
+  /// @param serializer_fn Serializer function to serialize the measurement
+  void registerMeasurementSerializer(std::string tag, MeasurementSerializer serializer_fn) {
+    measurement_serializers_[tag] = serializer_fn;
+  };
 };
 
 }  // namespace jrl

--- a/include/jrl/Writer.h
+++ b/include/jrl/Writer.h
@@ -31,18 +31,6 @@ class Writer {
    **/
   std::map<std::string, MeasurementSerializer> loadDefaultMeasurementSerializers();
 
-  /** @brief Serializes all values using the loaded value serializers
-   *  @param typed_values Input values and types
-   *  @return JSON serialized values
-   **/
-  json serializeValues(TypedValues typed_values) const;
-
-  /** @brief Serializes all measurements using the loaded measurement serializers
-   *  @param measurements Input entries containing temporally ordered measurements
-   *  @return JSON serialized measurements
-   **/
-  json serializeMeasurements(std::vector<Entry> measurements) const;
-
   /** @brief Writes arbitrary JSON To file
    * @param output_json: The json to write
    * @param output_file_name: The file in which to save the json
@@ -67,6 +55,18 @@ class Writer {
   /// @param compress_with_cbor if true indicates that written files should be compressed with cbor
   void writeMetricSummary(MetricSummary metric_summary, std::string output_file_name,
                           bool compress_to_cbor = false) const;
+
+  /** @brief Serializes all values using the loaded value serializers
+   *  @param typed_values Input values and types
+   *  @return JSON serialized values
+   **/
+  json serializeValues(TypedValues typed_values) const;
+
+  /** @brief Serializes all measurements using the loaded measurement serializers
+   *  @param measurements Input entries containing temporally ordered measurements
+   *  @return JSON serialized measurements
+   **/
+  json serializeMeasurements(std::vector<Entry> measurements) const;
 
   /// @brief Register a custom value serializer
   /// @param tag Tag to associate with the value

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -1,6 +1,7 @@
 #include <gtsam/nonlinear/NonlinearFactor.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/functional.h>
 
 #include "jrl/Dataset.h"
 #include "jrl/DatasetBuilder.h"
@@ -44,7 +45,7 @@ PYBIND11_MODULE(jrl_python, m) {
   m.attr("BearingRangeFactor2DTag") = py::str(BearingRangeFactor2DTag);
   m.attr("BearingRangeFactor3DTag") = py::str(BearingRangeFactor3DTag);
   m.attr("PriorFactorPoint2Tag") = py::str(PriorFactorPoint2Tag);
-  m.attr("PriorFactorPointTag") = py::str(PriorFactorPoint3Tag);
+  m.attr("PriorFactorPoint3Tag") = py::str(PriorFactorPoint3Tag);
   m.attr("BetweenFactorPoint2Tag") = py::str(BetweenFactorPoint2Tag);
   m.attr("BetweenFactorPoint3Tag") = py::str(BetweenFactorPoint3Tag);
 
@@ -67,6 +68,8 @@ PYBIND11_MODULE(jrl_python, m) {
       .def_readwrite("measurement_types", &Entry::measurement_types)
       .def_readwrite("measurements", &Entry::measurements)
       .def_readwrite("potential_outlier_statuses", &Entry::potential_outlier_statuses)
+      .def("remove", &Entry::remove)
+      .def("filter", &Entry::filter)
       .def(py::pickle(
           [](const Entry &entry) {  // __getstate__
             return py::make_tuple(entry.stamp, entry.measurement_types, entry.measurements,
@@ -142,6 +145,8 @@ PYBIND11_MODULE(jrl_python, m) {
       .def("addEntry", &DatasetBuilder::addEntry, py::arg("robot"), py::arg("stamp"), py::arg("measurements"),
            py::arg("measurement_types"), py::arg("potential_outlier_statuses") = {},
            py::arg("initialization") = py::none(), py::arg("groundtruth") = py::none())
+      .def("addGroundTruth", &DatasetBuilder::addGroundTruth, py::arg("robot"), py::arg("groundtruth"))
+      .def("addInitialization", &DatasetBuilder::addInitialization, py::arg("robot"), py::arg("initialization"))
       .def("build", &DatasetBuilder::build);
 
   /**

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -1,7 +1,7 @@
 #include <gtsam/nonlinear/NonlinearFactor.h>
+#include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <pybind11/functional.h>
 
 #include "jrl/Dataset.h"
 #include "jrl/DatasetBuilder.h"

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -68,8 +68,9 @@ PYBIND11_MODULE(jrl_python, m) {
       .def_readwrite("measurement_types", &Entry::measurement_types)
       .def_readwrite("measurements", &Entry::measurements)
       .def_readwrite("potential_outlier_statuses", &Entry::potential_outlier_statuses)
-      .def("remove", &Entry::remove)
-      .def("filter", &Entry::filter)
+      .def("filtered", &Entry::filtered)
+      .def_static("KeepTypes", &Entry::KeepTypes)
+      .def_static("RemoveTypes", &Entry::RemoveTypes)
       .def(py::pickle(
           [](const Entry &entry) {  // __getstate__
             return py::make_tuple(entry.stamp, entry.measurement_types, entry.measurements,

--- a/src/Dataset.cpp
+++ b/src/Dataset.cpp
@@ -15,8 +15,10 @@ Dataset::Dataset(const std::string name, std::vector<char> robots, std::map<char
   // Construct the factor graphs for each robot from the temporally ordered measurements
   for (const char& rid : robots_) {
     factor_graphs_[rid] = gtsam::NonlinearFactorGraph();
+    measurement_types_[rid] = std::set<std::string>();
     for (const Entry& entry : measurements_[rid]) {
       factor_graphs_[rid].push_back(entry.measurements);
+      measurement_types_[rid].insert(entry.measurement_types.begin(), entry.measurement_types.end());
     }
   }
 }
@@ -52,6 +54,11 @@ std::vector<Entry> Dataset::measurements(const boost::optional<char>& robot_id) 
 /**********************************************************************************************************************/
 gtsam::NonlinearFactorGraph Dataset::factorGraph(const boost::optional<char>& robot_id) const {
   return accessor<gtsam::NonlinearFactorGraph>("factorGraph", factor_graphs_, robot_id);
+}
+
+/**********************************************************************************************************************/
+std::set<std::string> Dataset::measurementTypes(const boost::optional<char>& robot_id) const {
+  return accessor<std::set<std::string>>("measurementTypes", measurement_types_, robot_id);
 }
 
 /**********************************************************************************************************************/

--- a/src/DatasetBuilder.cpp
+++ b/src/DatasetBuilder.cpp
@@ -19,14 +19,22 @@ void DatasetBuilder::addEntry(char robot, uint64_t stamp, gtsam::NonlinearFactor
                               const boost::optional<TypedValues> groundtruth) {
   measurements_[robot].push_back(Entry(stamp, measurement_types, measurements, potential_outlier_statuses));
   if (initialization) {
-    initial_estimates_[robot].values.insert((*initialization).values);
-    initial_estimates_[robot].types.insert((*initialization).types.begin(), (*initialization).types.end());
+    addInitialization(robot, *initialization);
   }
 
   if (groundtruth) {
-    ground_truth_[robot].values.insert((*groundtruth).values);
-    ground_truth_[robot].types.insert((*groundtruth).types.begin(), (*groundtruth).types.end());
+    addGroundTruth(robot, *groundtruth);
   }
+}
+
+void DatasetBuilder::addGroundTruth(char robot, TypedValues groundtruth) {
+  ground_truth_[robot].values.insert(groundtruth.values);
+  ground_truth_[robot].types.insert(groundtruth.types.begin(), groundtruth.types.end());
+}
+
+void DatasetBuilder::addInitialization(char robot, TypedValues initialization) {
+  initial_estimates_[robot].values.insert(initialization.values);
+  initial_estimates_[robot].types.insert(initialization.types.begin(), initialization.types.end());
 }
 
 Dataset DatasetBuilder::build() {

--- a/src/IOValues.cpp
+++ b/src/IOValues.cpp
@@ -135,7 +135,6 @@ json serialize<gtsam::Point3>(gtsam::Point3 point) {
   return output;
 }
 
-
 /**********************************************************************************************************************/
 // Unit3
 template <>
@@ -156,7 +155,6 @@ json serialize<gtsam::Unit3>(gtsam::Unit3 unit) {
   output["k"] = p.z();
   return output;
 }
-
 
 }  // namespace io_values
 }  // namespace jrl

--- a/src/Types.cpp
+++ b/src/Types.cpp
@@ -3,37 +3,29 @@
 namespace jrl {
 
 /**********************************************************************************************************************/
-Entry Entry::remove(std::vector<std::string> remove_types) {
-  std::vector<std::string> out_measurement_types;
-  gtsam::NonlinearFactorGraph out_measurements;
-  std::map<gtsam::FactorIndex, bool> out_potential_outlier_statuses;
-  gtsam::FactorIndex curr = 0;
-
-  for (uint64_t i = 0; i < measurement_types.size(); ++i) {
-    // If the type isn't in remove_types, keep it
-    if (std::find(remove_types.begin(), remove_types.end(), measurement_types[i]) == remove_types.end()) {
-      out_measurement_types.push_back(measurement_types[i]);
-      out_measurements.push_back(measurements[i]);
-      if (potential_outlier_statuses.find(i) != potential_outlier_statuses.end()) {
-        out_potential_outlier_statuses[curr] = potential_outlier_statuses[i];
-      }
-      curr += 1;
-    }
+EntryPredicate Entry::KeepTypes(std::vector<std::string> types) {
+    return [types](std::string type, gtsam::NonlinearFactor::shared_ptr&) {
+      return std::find(types.begin(), types.end(), type) != types.end();
+    };
   }
 
-  return Entry(stamp, out_measurement_types, out_measurements, out_potential_outlier_statuses);
-}
 
 /**********************************************************************************************************************/
-Entry Entry::filter(std::vector<std::string> filter_types) {
+EntryPredicate Entry::RemoveTypes(std::vector<std::string> types) {
+    return [types](std::string type, gtsam::NonlinearFactor::shared_ptr&) {
+      return std::find(types.begin(), types.end(), type) == types.end();
+    };
+  }
+
+/**********************************************************************************************************************/
+Entry Entry::filtered(EntryPredicate predicate) {
   std::vector<std::string> out_measurement_types;
   gtsam::NonlinearFactorGraph out_measurements;
   std::map<gtsam::FactorIndex, bool> out_potential_outlier_statuses;
   gtsam::FactorIndex curr = 0;
 
   for (uint64_t i = 0; i < measurement_types.size(); ++i) {
-    // If the type is in filter_types, keep it
-    if (std::find(filter_types.begin(), filter_types.end(), measurement_types[i]) != filter_types.end()) {
+    if (predicate(measurement_types[i], measurements[i])) {
       out_measurement_types.push_back(measurement_types[i]);
       out_measurements.push_back(measurements[i]);
       if (potential_outlier_statuses.find(i) != potential_outlier_statuses.end()) {

--- a/src/Types.cpp
+++ b/src/Types.cpp
@@ -3,21 +3,21 @@
 namespace jrl {
 
 /**********************************************************************************************************************/
-EntryPredicate Entry::KeepTypes(std::vector<std::string> types) {
+Entry::FilterPredicate Entry::KeepTypes(std::vector<std::string> types) {
   return [types](const std::string& type, const gtsam::NonlinearFactor::shared_ptr&) {
     return std::find(types.begin(), types.end(), type) != types.end();
   };
 }
 
 /**********************************************************************************************************************/
-EntryPredicate Entry::RemoveTypes(std::vector<std::string> types) {
+Entry::FilterPredicate Entry::RemoveTypes(std::vector<std::string> types) {
   return [types](const std::string& type, const gtsam::NonlinearFactor::shared_ptr&) {
     return std::find(types.begin(), types.end(), type) == types.end();
   };
 }
 
 /**********************************************************************************************************************/
-Entry Entry::filtered(EntryPredicate predicate) const {
+Entry Entry::filtered(Entry::FilterPredicate predicate) const {
   std::vector<std::string> out_measurement_types;
   gtsam::NonlinearFactorGraph out_measurements;
   std::map<gtsam::FactorIndex, bool> out_potential_outlier_statuses;

--- a/src/Types.cpp
+++ b/src/Types.cpp
@@ -4,18 +4,17 @@ namespace jrl {
 
 /**********************************************************************************************************************/
 EntryPredicate Entry::KeepTypes(std::vector<std::string> types) {
-    return [types](const std::string& type, const gtsam::NonlinearFactor::shared_ptr&) {
-      return std::find(types.begin(), types.end(), type) != types.end();
-    };
-  }
-
+  return [types](const std::string& type, const gtsam::NonlinearFactor::shared_ptr&) {
+    return std::find(types.begin(), types.end(), type) != types.end();
+  };
+}
 
 /**********************************************************************************************************************/
 EntryPredicate Entry::RemoveTypes(std::vector<std::string> types) {
-    return [types](const std::string& type, const gtsam::NonlinearFactor::shared_ptr&) {
-      return std::find(types.begin(), types.end(), type) == types.end();
-    };
-  }
+  return [types](const std::string& type, const gtsam::NonlinearFactor::shared_ptr&) {
+    return std::find(types.begin(), types.end(), type) == types.end();
+  };
+}
 
 /**********************************************************************************************************************/
 Entry Entry::filtered(EntryPredicate predicate) const {

--- a/src/Types.cpp
+++ b/src/Types.cpp
@@ -4,7 +4,7 @@ namespace jrl {
 
 /**********************************************************************************************************************/
 EntryPredicate Entry::KeepTypes(std::vector<std::string> types) {
-    return [types](std::string type, gtsam::NonlinearFactor::shared_ptr&) {
+    return [types](const std::string& type, const gtsam::NonlinearFactor::shared_ptr&) {
       return std::find(types.begin(), types.end(), type) != types.end();
     };
   }
@@ -12,13 +12,13 @@ EntryPredicate Entry::KeepTypes(std::vector<std::string> types) {
 
 /**********************************************************************************************************************/
 EntryPredicate Entry::RemoveTypes(std::vector<std::string> types) {
-    return [types](std::string type, gtsam::NonlinearFactor::shared_ptr&) {
+    return [types](const std::string& type, const gtsam::NonlinearFactor::shared_ptr&) {
       return std::find(types.begin(), types.end(), type) == types.end();
     };
   }
 
 /**********************************************************************************************************************/
-Entry Entry::filtered(EntryPredicate predicate) {
+Entry Entry::filtered(EntryPredicate predicate) const {
   std::vector<std::string> out_measurement_types;
   gtsam::NonlinearFactorGraph out_measurements;
   std::map<gtsam::FactorIndex, bool> out_potential_outlier_statuses;
@@ -29,7 +29,7 @@ Entry Entry::filtered(EntryPredicate predicate) {
       out_measurement_types.push_back(measurement_types[i]);
       out_measurements.push_back(measurements[i]);
       if (potential_outlier_statuses.find(i) != potential_outlier_statuses.end()) {
-        out_potential_outlier_statuses[curr] = potential_outlier_statuses[i];
+        out_potential_outlier_statuses[curr] = potential_outlier_statuses.at(i);
       }
       curr += 1;
     }

--- a/src/Types.cpp
+++ b/src/Types.cpp
@@ -1,0 +1,49 @@
+#include "jrl/Types.h"
+
+namespace jrl {
+
+/**********************************************************************************************************************/
+Entry Entry::remove(std::vector<std::string> remove_types) {
+  std::vector<std::string> out_measurement_types;
+  gtsam::NonlinearFactorGraph out_measurements;
+  std::map<gtsam::FactorIndex, bool> out_potential_outlier_statuses;
+  gtsam::FactorIndex curr = 0;
+
+  for (uint64_t i = 0; i < measurement_types.size(); ++i) {
+    // If the type isn't in remove_types, keep it
+    if (std::find(remove_types.begin(), remove_types.end(), measurement_types[i]) == remove_types.end()) {
+      out_measurement_types.push_back(measurement_types[i]);
+      out_measurements.push_back(measurements[i]);
+      if (potential_outlier_statuses.find(i) != potential_outlier_statuses.end()) {
+        out_potential_outlier_statuses[curr] = potential_outlier_statuses[i];
+      }
+      curr += 1;
+    }
+  }
+
+  return Entry(stamp, out_measurement_types, out_measurements, out_potential_outlier_statuses);
+}
+
+/**********************************************************************************************************************/
+Entry Entry::filter(std::vector<std::string> filter_types) {
+  std::vector<std::string> out_measurement_types;
+  gtsam::NonlinearFactorGraph out_measurements;
+  std::map<gtsam::FactorIndex, bool> out_potential_outlier_statuses;
+  gtsam::FactorIndex curr = 0;
+
+  for (uint64_t i = 0; i < measurement_types.size(); ++i) {
+    // If the type is in filter_types, keep it
+    if (std::find(filter_types.begin(), filter_types.end(), measurement_types[i]) != filter_types.end()) {
+      out_measurement_types.push_back(measurement_types[i]);
+      out_measurements.push_back(measurements[i]);
+      if (potential_outlier_statuses.find(i) != potential_outlier_statuses.end()) {
+        out_potential_outlier_statuses[curr] = potential_outlier_statuses[i];
+      }
+      curr += 1;
+    }
+  }
+
+  return Entry(stamp, out_measurement_types, out_measurements, out_potential_outlier_statuses);
+}
+
+}  // namespace jrl

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,6 +1,6 @@
 #include "gtest/gtest.h"
 
 int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }

--- a/tests/test_Custom.cpp
+++ b/tests/test_Custom.cpp
@@ -3,73 +3,81 @@
 #include <gtsam/slam/StereoFactor.h>
 #include <jrl/Dataset.h>
 #include <jrl/DatasetBuilder.h>
-#include <jrl/Parser.h>
-#include <jrl/Writer.h>
 #include <jrl/IOMeasurements.h>
 #include <jrl/IOValues.h>
+#include <jrl/Parser.h>
+#include <jrl/Writer.h>
 
 #include "gtest/gtest.h"
 
-using gtsam::symbol_shorthand::X;
-using gtsam::symbol_shorthand::V;
 using gtsam::symbol_shorthand::B;
+using gtsam::symbol_shorthand::V;
+using gtsam::symbol_shorthand::X;
 
 #define EXPECT_MATRICES_EQ(M_actual, M_expected) \
   EXPECT_TRUE(M_actual.isApprox(M_expected, 1e-6)) << "  Actual:\n" << M_actual << "\nExpected:\n" << M_expected
 
+TEST(Custom, Factor) {
+  // Make dummy factors
+  gtsam::noiseModel::Gaussian::shared_ptr cov = gtsam::noiseModel::Gaussian::Covariance(Eigen::Matrix3d::Identity());
+  gtsam::PriorFactor<gtsam::Pose2> prior(X(0), gtsam::Pose2::Identity(), cov);
+  std::string customType = "CustomFactor";
 
-TEST(Custom, Factor){
-    // Make dummy factors
-    gtsam::noiseModel::Gaussian::shared_ptr cov = gtsam::noiseModel::Gaussian::Covariance(Eigen::Matrix3d::Identity());
-    gtsam::PriorFactor<gtsam::Pose2> prior(X(0), gtsam::Pose2::Identity(), cov);
-    std::string customType = "CustomFactor";
+  // Make dataset
+  gtsam::NonlinearFactorGraph graph;
+  graph.push_back(prior);
+  jrl::Entry entry(0, {customType}, graph);
 
-    // Make dataset
-    gtsam::NonlinearFactorGraph graph;
-    graph.push_back(prior);
-    jrl::Entry entry(0, {customType}, graph);
+  // Make custom writer/parser (Copied from prior information)
+  jrl::Writer writer;
+  writer.registerMeasurementSerializer(customType, [customType](gtsam::NonlinearFactor::shared_ptr& factor) {
+    return jrl::io_measurements::serializePrior<gtsam::Pose2>(&jrl::io_values::serialize<gtsam::Pose2>, customType,
+                                                              factor);
+  });
 
-    // Make custom writer/parser (Copied from prior information)
-    jrl::Writer writer;
-    writer.registerMeasurementSerializer(customType, [customType](gtsam::NonlinearFactor::shared_ptr& factor) { return jrl::io_measurements::serializePrior<gtsam::Pose2>(&jrl::io_values::serialize<gtsam::Pose2>, customType, factor); });
+  jrl::Parser parser;
+  parser.registerMeasurementParser(customType, [](const json& input) {
+    return jrl::io_measurements::parsePrior<gtsam::Pose2>(&jrl::io_values::parse<gtsam::Pose2>, input);
+  });
 
-    jrl::Parser parser;
-    parser.registerMeasurementParser(customType, [](const json& input){ return jrl::io_measurements::parsePrior<gtsam::Pose2>(&jrl::io_values::parse<gtsam::Pose2>, input); });
+  // Send it round trip!
+  auto serialized = writer.serializeMeasurements({entry});
+  jrl::Entry read = parser.parseMeasurements(serialized)[0];
+  gtsam::PriorFactor<gtsam::Pose2>::shared_ptr read_factor =
+      boost::dynamic_pointer_cast<gtsam::PriorFactor<gtsam::Pose2>>(entry.measurements.at(0));
 
-    // Send it round trip!
-    auto serialized = writer.serializeMeasurements({entry});
-    jrl::Entry read = parser.parseMeasurements(serialized)[0];
-    gtsam::PriorFactor<gtsam::Pose2>::shared_ptr read_factor = boost::dynamic_pointer_cast<gtsam::PriorFactor<gtsam::Pose2>>(entry.measurements.at(0));
-
-    EXPECT_TRUE(prior.equals(*read_factor));
+  EXPECT_TRUE(prior.equals(*read_factor));
 }
 
+TEST(Custom, Value) {
+  // Make dummy factors
+  gtsam::Pose2 x(1, 2, 3);
+  std::string customType = "CustomValue";
 
-TEST(Custom, Value){
-    // Make dummy factors
-    gtsam::Pose2 x(1,2,3);
-    std::string customType = "CustomValue";
+  gtsam::NonlinearFactorGraph graph;
+  gtsam::Values theta;
+  jrl::ValueTypes types;
 
-    gtsam::NonlinearFactorGraph graph;
-    gtsam::Values theta;
-    jrl::ValueTypes types;
+  // Make dataset
+  theta.insert(X(0), x);
+  types[X(0)] = customType;
+  jrl::TypedValues typed_values(theta, types);
 
-    // Make dataset
-    theta.insert(X(0), x);
-    types[X(0)] = customType;
-    jrl::TypedValues typed_values(theta, types);
+  // Make custom writer/parser (Copied from prior information)
+  jrl::Writer writer;
+  writer.registerValueSerializer(customType, [customType](gtsam::Key key, gtsam::Values& vals) {
+    return jrl::io_values::serialize<gtsam::Pose2>(vals.at<gtsam::Pose2>(key));
+  });
 
-    // Make custom writer/parser (Copied from prior information)
-    jrl::Writer writer;
-    writer.registerValueSerializer(customType, [customType](gtsam::Key key, gtsam::Values& vals) { return jrl::io_values::serialize<gtsam::Pose2>(vals.at<gtsam::Pose2>(key)); });
+  jrl::Parser parser;
+  parser.registerValueParser(customType, [](const json& input, gtsam::Key key, gtsam::Values& accum) {
+    return jrl::io_values::valueAccumulator<gtsam::Pose2>(&jrl::io_values::parse<gtsam::Pose2>, input, key, accum);
+  });
 
-    jrl::Parser parser;
-    parser.registerValueParser(customType, [](const json& input, gtsam::Key key, gtsam::Values& accum) { return jrl::io_values::valueAccumulator<gtsam::Pose2>(&jrl::io_values::parse<gtsam::Pose2>, input, key, accum); });
+  // Send it round trip!
+  auto serialized = writer.serializeValues(typed_values);
+  gtsam::Values read = parser.parseValues(serialized).values;
+  gtsam::Pose2 x_read = read.at<gtsam::Pose2>(X(0));
 
-    // Send it round trip!
-    auto serialized = writer.serializeValues(typed_values);
-    gtsam::Values read = parser.parseValues(serialized).values;
-    gtsam::Pose2 x_read = read.at<gtsam::Pose2>(X(0));
-
-    EXPECT_TRUE(x.equals(x_read));
+  EXPECT_TRUE(x.equals(x_read));
 }

--- a/tests/test_Custom.cpp
+++ b/tests/test_Custom.cpp
@@ -1,0 +1,78 @@
+#include <gtsam/geometry/Cal3_S2Stereo.h>
+#include <gtsam/geometry/StereoPoint2.h>
+#include <gtsam/slam/StereoFactor.h>
+#include <jrl/Dataset.h>
+#include <jrl/DatasetBuilder.h>
+#include <jrl/Parser.h>
+#include <jrl/Writer.h>
+#include <jrl/IOMeasurements.h>
+#include <jrl/IOValues.h>
+
+#include "gtest/gtest.h"
+
+using gtsam::symbol_shorthand::X;
+using gtsam::symbol_shorthand::V;
+using gtsam::symbol_shorthand::B;
+
+#define EXPECT_MATRICES_EQ(M_actual, M_expected) \
+  EXPECT_TRUE(M_actual.isApprox(M_expected, 1e-6)) << "  Actual:\n" << M_actual << "\nExpected:\n" << M_expected
+
+
+TEST(Custom, Factor){
+    // Make dummy factors
+    gtsam::noiseModel::Gaussian::shared_ptr cov = gtsam::noiseModel::Gaussian::Covariance(Eigen::Matrix3d::Identity());
+    gtsam::PriorFactor<gtsam::Pose2> prior(X(0), gtsam::Pose2::Identity(), cov);
+    std::string customType = "CustomFactor";
+
+    // Make dataset
+    gtsam::NonlinearFactorGraph graph;
+    graph.push_back(prior);
+    jrl::DatasetBuilder builder("test", {'a'});
+    builder.addEntry('a', 0, graph, {customType});
+
+    // Make custom writer/parser (Copied from prior information)
+    jrl::Writer writer;
+    writer.registerMeasurementSerializer(customType, [customType](gtsam::NonlinearFactor::shared_ptr& factor) { return jrl::io_measurements::serializePrior<gtsam::Pose2>(&jrl::io_values::serialize<gtsam::Pose2>, customType, factor); });
+
+    jrl::Parser parser;
+    parser.registerMeasurementParser(customType, [](const json& input){ return jrl::io_measurements::parsePrior<gtsam::Pose2>(&jrl::io_values::parse<gtsam::Pose2>, input); });
+
+    // Send it round trip!
+    writer.writeDataset(builder.build(), "custom.jrl");
+    jrl::Dataset dataset = parser.parseDataset("custom.jrl");
+    gtsam::PriorFactor<gtsam::Pose2>::shared_ptr read_factor = boost::dynamic_pointer_cast<gtsam::PriorFactor<gtsam::Pose2>>(dataset.factorGraph('a')[0]);
+
+    EXPECT_TRUE(prior.equals(*read_factor));
+}
+
+
+TEST(Custom, Value){
+    // Make dummy factors
+    gtsam::Pose2 x(1,2,3);
+    std::string customType = "CustomValue";
+
+    gtsam::NonlinearFactorGraph graph;
+    gtsam::Values theta;
+    jrl::ValueTypes types;
+
+    // Make dataset
+    theta.insert(X(0), x);
+    types[X(0)] = customType;
+
+    jrl::DatasetBuilder builder("test", {'a'});
+    builder.addEntry('a', 0, graph, {}, {}, jrl::TypedValues(theta, types));
+
+    // Make custom writer/parser (Copied from prior information)
+    jrl::Writer writer;
+    writer.registerValueSerializer(customType, [customType](gtsam::Key key, gtsam::Values& vals) { return jrl::io_values::serialize<gtsam::Pose2>(vals.at<gtsam::Pose2>(key)); });
+
+    jrl::Parser parser;
+    parser.registerValueParser(customType, [](const json& input, gtsam::Key key, gtsam::Values& accum) { return jrl::io_values::valueAccumulator<gtsam::Pose2>(&jrl::io_values::parse<gtsam::Pose2>, input, key, accum); });
+
+    // Send it round trip!
+    writer.writeDataset(builder.build(), "custom.jrl");
+    jrl::Dataset dataset = parser.parseDataset("custom.jrl");
+    gtsam::Pose2 x_read = dataset.initialization('a').at<gtsam::Pose2>(X(0));
+
+    EXPECT_MATRICES_EQ(x.matrix(), x_read.matrix());
+}

--- a/tests/test_Types.cpp
+++ b/tests/test_Types.cpp
@@ -32,7 +32,8 @@ TEST(Types, EntryRemove){
     std::map<gtsam::FactorIndex, bool> potential_outlier_statuses{{0, false}, {1, true}};
     jrl::Entry entry = jrl::Entry(0, tags, graph, potential_outlier_statuses);
 
-    jrl::Entry split = entry.remove({jrl::BetweenFactorPose2Tag});
+    auto pred = jrl::Entry::RemoveTypes({jrl::BetweenFactorPose2Tag});
+    jrl::Entry split = entry.filtered(pred);
     
     EXPECT_EQ(1, split.measurements.size());
     EXPECT_EQ(1, split.measurement_types.size());
@@ -41,7 +42,7 @@ TEST(Types, EntryRemove){
     EXPECT_FALSE(split.potential_outlier_statuses[0]);
 }
 
-TEST(Types, EntryFilter){
+TEST(Types, EntryKeep){
     // Make dummy factors
     gtsam::noiseModel::Gaussian::shared_ptr cov = gtsam::noiseModel::Gaussian::Covariance(Eigen::Matrix3d::Identity());
     gtsam::PriorFactor<gtsam::Pose2> factor_prior(X(0), gtsam::Pose2::Identity(), cov);
@@ -56,7 +57,8 @@ TEST(Types, EntryFilter){
     std::map<gtsam::FactorIndex, bool> potential_outlier_statuses{{0, false}, {1, true}};
     jrl::Entry entry = jrl::Entry(0, tags, graph, potential_outlier_statuses);
 
-    jrl::Entry split = entry.filter({jrl::BetweenFactorPose2Tag});
+    auto pred = jrl::Entry::KeepTypes({jrl::BetweenFactorPose2Tag});
+    jrl::Entry split = entry.filtered(pred);
     
     EXPECT_EQ(1, split.measurements.size());
     EXPECT_EQ(1, split.measurement_types.size());

--- a/tests/test_Types.cpp
+++ b/tests/test_Types.cpp
@@ -3,66 +3,65 @@
 #include <gtsam/slam/StereoFactor.h>
 #include <jrl/Dataset.h>
 #include <jrl/DatasetBuilder.h>
+#include <jrl/IOMeasurements.h>
 #include <jrl/Parser.h>
 #include <jrl/Writer.h>
-#include <jrl/IOMeasurements.h>
 
 #include "gtest/gtest.h"
 
-using gtsam::symbol_shorthand::X;
-using gtsam::symbol_shorthand::V;
 using gtsam::symbol_shorthand::B;
+using gtsam::symbol_shorthand::V;
+using gtsam::symbol_shorthand::X;
 
 #define EXPECT_MATRICES_EQ(M_actual, M_expected) \
   EXPECT_TRUE(M_actual.isApprox(M_expected, 1e-6)) << "  Actual:\n" << M_actual << "\nExpected:\n" << M_expected
 
+TEST(Types, EntryRemove) {
+  // Make dummy factors
+  gtsam::noiseModel::Gaussian::shared_ptr cov = gtsam::noiseModel::Gaussian::Covariance(Eigen::Matrix3d::Identity());
+  gtsam::PriorFactor<gtsam::Pose2> factor_prior(X(0), gtsam::Pose2::Identity(), cov);
+  gtsam::BetweenFactor<gtsam::Pose2> factor_between(X(0), X(1), gtsam::Pose2::Identity(), cov);
 
-TEST(Types, EntryRemove){
-    // Make dummy factors
-    gtsam::noiseModel::Gaussian::shared_ptr cov = gtsam::noiseModel::Gaussian::Covariance(Eigen::Matrix3d::Identity());
-    gtsam::PriorFactor<gtsam::Pose2> factor_prior(X(0), gtsam::Pose2::Identity(), cov);
-    gtsam::BetweenFactor<gtsam::Pose2> factor_between(X(0), X(1), gtsam::Pose2::Identity(), cov);
+  // Make dataset
+  gtsam::NonlinearFactorGraph graph;
+  graph.push_back(factor_prior);
+  graph.push_back(factor_between);
 
-    // Make dataset
-    gtsam::NonlinearFactorGraph graph;
-    graph.push_back(factor_prior);
-    graph.push_back(factor_between);
+  std::vector<std::string> tags{jrl::PriorFactorPose2Tag, jrl::BetweenFactorPose2Tag};
+  std::map<gtsam::FactorIndex, bool> potential_outlier_statuses{{0, false}, {1, true}};
+  jrl::Entry entry = jrl::Entry(0, tags, graph, potential_outlier_statuses);
 
-    std::vector<std::string> tags{jrl::PriorFactorPose2Tag, jrl::BetweenFactorPose2Tag};
-    std::map<gtsam::FactorIndex, bool> potential_outlier_statuses{{0, false}, {1, true}};
-    jrl::Entry entry = jrl::Entry(0, tags, graph, potential_outlier_statuses);
+  auto pred = jrl::Entry::RemoveTypes({jrl::BetweenFactorPose2Tag});
+  jrl::Entry split = entry.filtered(pred);
 
-    auto pred = jrl::Entry::RemoveTypes({jrl::BetweenFactorPose2Tag});
-    jrl::Entry split = entry.filtered(pred);
-    
-    EXPECT_EQ(1, split.measurements.size());
-    EXPECT_EQ(1, split.measurement_types.size());
-    EXPECT_EQ(jrl::PriorFactorPose2Tag, split.measurement_types[0]);
-    EXPECT_TRUE(factor_prior.equals(*split.measurements[0]));
-    EXPECT_FALSE(split.potential_outlier_statuses[0]);
+  EXPECT_EQ(1, split.measurements.size());
+  EXPECT_EQ(1, split.measurement_types.size());
+  EXPECT_EQ(jrl::PriorFactorPose2Tag, split.measurement_types[0]);
+  EXPECT_TRUE(factor_prior.equals(*split.measurements[0]));
+  EXPECT_FALSE(split.potential_outlier_statuses[0]);
 }
 
-TEST(Types, EntryKeep){
-    // Make dummy factors
-    gtsam::noiseModel::Gaussian::shared_ptr cov = gtsam::noiseModel::Gaussian::Covariance(Eigen::Matrix3d::Identity());
-    gtsam::PriorFactor<gtsam::Pose2> factor_prior(X(0), gtsam::Pose2::Identity(), cov);
-    gtsam::BetweenFactor<gtsam::Pose2> factor_between(X(0), X(1), gtsam::Pose2::Identity(), cov);
+TEST(Types, EntryKeep) {
+  // Make dummy factors
+  gtsam::noiseModel::Gaussian::shared_ptr cov = gtsam::noiseModel::Gaussian::Covariance(Eigen::Matrix3d::Identity());
+  gtsam::PriorFactor<gtsam::Pose2> factor_prior(X(0), gtsam::Pose2::Identity(), cov);
+  gtsam::BetweenFactor<gtsam::Pose2> factor_between(X(0), X(1), gtsam::Pose2::Identity(), cov);
 
-    // Make dataset
-    gtsam::NonlinearFactorGraph graph;
-    graph.push_back(factor_prior);
-    graph.push_back(factor_between);
+  // Make dataset
+  gtsam::NonlinearFactorGraph graph;
+  graph.push_back(factor_prior);
+  graph.push_back(factor_between);
 
-    std::vector<std::string> tags{jrl::PriorFactorPose2Tag, jrl::BetweenFactorPose2Tag};
-    std::map<gtsam::FactorIndex, bool> potential_outlier_statuses{{0, false}, {1, true}};
-    jrl::Entry entry = jrl::Entry(0, tags, graph, potential_outlier_statuses);
+  std::vector<std::string> tags{jrl::PriorFactorPose2Tag, jrl::BetweenFactorPose2Tag};
+  std::map<gtsam::FactorIndex, bool> potential_outlier_statuses{{0, false}, {1, true}};
+  jrl::Entry entry = jrl::Entry(0, tags, graph, potential_outlier_statuses);
 
-    auto pred = jrl::Entry::KeepTypes({jrl::BetweenFactorPose2Tag});
-    jrl::Entry split = entry.filtered(pred);
-    
-    EXPECT_EQ(1, split.measurements.size());
-    EXPECT_EQ(1, split.measurement_types.size());
-    EXPECT_EQ(jrl::BetweenFactorPose2Tag, split.measurement_types[0]);
-    EXPECT_TRUE(factor_between.equals(*split.measurements[0]));
-    EXPECT_TRUE(split.potential_outlier_statuses[0]);
+  auto pred = jrl::Entry::KeepTypes({jrl::BetweenFactorPose2Tag});
+  jrl::Entry split = entry.filtered(pred);
+
+  EXPECT_EQ(1, split.measurements.size());
+  EXPECT_EQ(1, split.measurement_types.size());
+  EXPECT_EQ(jrl::BetweenFactorPose2Tag, split.measurement_types[0]);
+  EXPECT_TRUE(factor_between.equals(*split.measurements[0]));
+  EXPECT_TRUE(split.potential_outlier_statuses[0]);
 }

--- a/tests/test_Types.cpp
+++ b/tests/test_Types.cpp
@@ -1,0 +1,66 @@
+#include <gtsam/geometry/Cal3_S2Stereo.h>
+#include <gtsam/geometry/StereoPoint2.h>
+#include <gtsam/slam/StereoFactor.h>
+#include <jrl/Dataset.h>
+#include <jrl/DatasetBuilder.h>
+#include <jrl/Parser.h>
+#include <jrl/Writer.h>
+#include <jrl/IOMeasurements.h>
+
+#include "gtest/gtest.h"
+
+using gtsam::symbol_shorthand::X;
+using gtsam::symbol_shorthand::V;
+using gtsam::symbol_shorthand::B;
+
+#define EXPECT_MATRICES_EQ(M_actual, M_expected) \
+  EXPECT_TRUE(M_actual.isApprox(M_expected, 1e-6)) << "  Actual:\n" << M_actual << "\nExpected:\n" << M_expected
+
+
+TEST(Types, EntryRemove){
+    // Make dummy factors
+    gtsam::noiseModel::Gaussian::shared_ptr cov = gtsam::noiseModel::Gaussian::Covariance(Eigen::Matrix3d::Identity());
+    gtsam::PriorFactor<gtsam::Pose2> factor_prior(X(0), gtsam::Pose2::Identity(), cov);
+    gtsam::BetweenFactor<gtsam::Pose2> factor_between(X(0), X(1), gtsam::Pose2::Identity(), cov);
+
+    // Make dataset
+    gtsam::NonlinearFactorGraph graph;
+    graph.push_back(factor_prior);
+    graph.push_back(factor_between);
+
+    std::vector<std::string> tags{jrl::PriorFactorPose2Tag, jrl::BetweenFactorPose2Tag};
+    std::map<gtsam::FactorIndex, bool> potential_outlier_statuses{{0, false}, {1, true}};
+    jrl::Entry entry = jrl::Entry(0, tags, graph, potential_outlier_statuses);
+
+    jrl::Entry split = entry.remove({jrl::BetweenFactorPose2Tag});
+    
+    EXPECT_EQ(1, split.measurements.size());
+    EXPECT_EQ(1, split.measurement_types.size());
+    EXPECT_EQ(jrl::PriorFactorPose2Tag, split.measurement_types[0]);
+    EXPECT_TRUE(factor_prior.equals(*split.measurements[0]));
+    EXPECT_FALSE(split.potential_outlier_statuses[0]);
+}
+
+TEST(Types, EntryFilter){
+    // Make dummy factors
+    gtsam::noiseModel::Gaussian::shared_ptr cov = gtsam::noiseModel::Gaussian::Covariance(Eigen::Matrix3d::Identity());
+    gtsam::PriorFactor<gtsam::Pose2> factor_prior(X(0), gtsam::Pose2::Identity(), cov);
+    gtsam::BetweenFactor<gtsam::Pose2> factor_between(X(0), X(1), gtsam::Pose2::Identity(), cov);
+
+    // Make dataset
+    gtsam::NonlinearFactorGraph graph;
+    graph.push_back(factor_prior);
+    graph.push_back(factor_between);
+
+    std::vector<std::string> tags{jrl::PriorFactorPose2Tag, jrl::BetweenFactorPose2Tag};
+    std::map<gtsam::FactorIndex, bool> potential_outlier_statuses{{0, false}, {1, true}};
+    jrl::Entry entry = jrl::Entry(0, tags, graph, potential_outlier_statuses);
+
+    jrl::Entry split = entry.filter({jrl::BetweenFactorPose2Tag});
+    
+    EXPECT_EQ(1, split.measurements.size());
+    EXPECT_EQ(1, split.measurement_types.size());
+    EXPECT_EQ(jrl::BetweenFactorPose2Tag, split.measurement_types[0]);
+    EXPECT_TRUE(factor_between.equals(*split.measurements[0]));
+    EXPECT_TRUE(split.potential_outlier_statuses[0]);
+}


### PR DESCRIPTION
This is a handful of feature I found helpful in my own code using JRL. Figured I'd share if you think it's worthwhile having in the main codebase. These include:

- `addGroundTruth` and `addInitialization` functions in DatasetBuilder. This allows for setting these independently since they're not saved in the `Entry` anyways.
- Custom parsers/serializers support. There was a stub that needed filling out for this and it just took a couple lines of code. Also added tests for it.
- filtering/removing certain measurement types from `Entry`. For my purposes, I added all my wheel factors to a single jrl file, then used the filter functionality to only run on the one I was interested in. Tests also included.

Let me know what you think! Happy to split this up however if you're interested in some features, but not others.