### PR TITLE
Move create jrlConfig to main CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,6 @@ install(
 include(cmake/HandleUninstall.cmake) # for "make jrl-uninstall"
 
 # Setup configuration for find_package
-include(../cmake/MakeConfigFile.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/MakeConfigFile.cmake)
 MakeConfigFile(jrl)
 export(EXPORT jrl-exports FILE ${CMAKE_CURRENT_BINARY_DIR}/jrl-exports.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,17 +19,6 @@ target_include_directories(jrl PUBLIC
     $<INSTALL_INTERFACE:include/>
 )
 
-# INSTALL: JRL Library
-install(
-	TARGETS jrl
-    EXPORT jrl-exports
-	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/jrl)
-include(cmake/HandleUninstall.cmake) # for "make jrl-uninstall"
-
-
 # Build Tests for JRL if configured
 option(JRL_BUILD_TESTS "Build unit tests" OFF)
 if (${JRL_BUILD_TESTS})
@@ -41,3 +30,18 @@ option(JRL_BUILD_PYTHON "Build python bindings" OFF)
 if (${JRL_BUILD_PYTHON})
     add_subdirectory(python)
 endif()
+
+# INSTALL: JRL Library
+install(
+	TARGETS jrl
+    EXPORT jrl-exports
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/jrl)
+include(cmake/HandleUninstall.cmake) # for "make jrl-uninstall"
+
+# Setup configuration for find_package
+include(../cmake/MakeConfigFile.cmake)
+MakeConfigFile(jrl)
+export(EXPORT jrl-exports FILE ${CMAKE_CURRENT_BINARY_DIR}/jrl-exports.cmake)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -49,9 +49,3 @@ add_custom_target(jrl-python-install
 add_custom_target(jrl-python-uninstall
         COMMAND ${Python_EXECUTABLE} -m pip uninstall jrl
         WORKING_DIRECTORY ${JRL_PYTHON_BUILD_DIRECTORY})
-
-
-# Setup configuration for find_package
-include(../cmake/MakeConfigFile.cmake)
-MakeConfigFile(jrl)
-export(EXPORT jrl-exports FILE ${CMAKE_CURRENT_BINARY_DIR}/jrl-exports.cmake)


### PR DESCRIPTION
Previously there was an issue that the jrlConfig.cmake file was only generated if the project was configured to build python bindings. This fixes issue #16