### PR TITLE
Improved Outlier Scheme

### DIFF
--- a/format/DATASET_FORMAT.md
+++ b/format/DATASET_FORMAT.md
@@ -19,12 +19,12 @@ A dataset is a JSON object that contains the following components:
   # (Optional) Map[char -> Values] - The initial estimate for the values for each robot in the dataset (used for batch algorithms)
   "initialization": {"a": {...}, "b": {...}}
 
-  # (Optional) [List-of-FactorId] - The set of factors that are potentially outliers (i.e. Loop Closures)
+  # (Optional) Map[char -> [List-of-FactorId]] - The set of factors that are potentially outliers for each robot (i.e. Loop Closures)
   # If not included all measurements are assumed to be known inliers
-  "potential_outlier_factors": [ [0, 2], [4, 0] ...]
+  "potential_outlier_factors": {"a": [ [0, 2], [4, 0] ...], ...}
 
-  # (Optional) [List-of-FactorId] - The set of ground truth outlier factors
-  "outlier_factors": [[4, 0], ...]
+  # (Optional) Map[char -> [List-of-FactorId]] - The set of ground truth outlier factors for each robot
+  "outlier_factors": {"a": [[4, 0], ...], ...}
 }
 ```
 

--- a/format/DATASET_FORMAT.md
+++ b/format/DATASET_FORMAT.md
@@ -18,6 +18,13 @@ A dataset is a JSON object that contains the following components:
 
   # (Optional) Map[char -> Values] - The initial estimate for the values for each robot in the dataset (used for batch algorithms)
   "initialization": {"a": {...}, "b": {...}}
+
+  # (Optional) [List-of-FactorId] - The set of factors that are potentially outliers (i.e. Loop Closures)
+  # If not included all measurements are assumed to be known inliers
+  "potential_outlier_factors": [ [0, 2], [4, 0] ...]
+
+  # (Optional) [List-of-FactorId] - The set of ground truth outlier factors
+  "outlier_factors": [[4, 0], ...]
 }
 ```
 
@@ -29,13 +36,12 @@ Where an entry represents a set of measurements taken at a specific time and has
 
   # List-of-Measurement - The measurements taken at timestamp stamp
   "measurements": [...]
-
-  # (Optional) Map[uint64_t -> bool] - Mapping of factor indicies (in "measurements") to their outlier status
-  # If a factor index appears as a key it is possibly an outlier measurement (e.g. loop-closures)
-  # The value for each key indicates if the meaurement is actually an outlier
-  "potential_outlier_statuses": {"2": false, "6": true, ...}
 }
 ```
+
+And a FactorId = `Pair[uint64_t, uint64_t]` represents a unique identifier of a measurement by:
+  - "Entry Index" - The index of the entry to which the factor belongs
+  - "Measurement Index" - The index of the measurement within the entry at the Entry Index
 
 For the definition of Values format see `VALUE_FORMAT.md`.
 For the definition of Measurement formats see `MEASUREMENT_FORMAT.md`.

--- a/include/jrl/DatasetBuilder.h
+++ b/include/jrl/DatasetBuilder.h
@@ -47,10 +47,12 @@ class DatasetBuilder {
   void addInitialization(char robot, TypedValues initialization);
 
   /// @brief Add information for the potential outliers of the dataset
-  void addPotentialOutlierFactors(char robot, std::set<FactorId> potential_outlier_factors);
+  /// WARN: Overwrites any currently stored potential outlier factors
+  void setPotentialOutlierFactors(char robot, std::set<FactorId> potential_outlier_factors);
 
   /// @brief Add information on the true inliers of the dataset
-  void addOutlierFactors(char robot, std::set<FactorId> outlier_factors);
+  /// WARN: Overwrites any currently stored potential outlier factors
+  void setOutlierFactors(char robot, std::set<FactorId> outlier_factors);
 
   /// @brief Compiles a dataset from all the added entries
   Dataset build();

--- a/include/jrl/DatasetBuilder.h
+++ b/include/jrl/DatasetBuilder.h
@@ -24,6 +24,10 @@ class DatasetBuilder {
   std::map<char, TypedValues> initial_estimates_;
   /// @brief The measurements for each robot in the dataset
   std::map<char, std::vector<Entry>> measurements_;
+  /// @brief The set of measurements that are potentially outliers
+  std::map<char, std::set<FactorId>> potential_outlier_factors_;
+  /// @brief The set of measurements that are known inliers
+  std::map<char, std::set<FactorId>> outlier_factors_;
 
   /* INTERFACE */
  public:
@@ -33,7 +37,6 @@ class DatasetBuilder {
   /// @brief Adds information to the dataset incrementally for a single entry
   void addEntry(char robot, uint64_t stamp, gtsam::NonlinearFactorGraph measurements,
                 std::vector<std::string> measurement_types,
-                std::map<gtsam::FactorIndex, bool> potential_outlier_statuses = {},
                 const boost::optional<TypedValues> initialization = boost::none,
                 const boost::optional<TypedValues> groundtruth = boost::none);
 
@@ -42,6 +45,12 @@ class DatasetBuilder {
 
   /// @brief Adds initial estimate information for a single robot. Can be used incrementally or in bulk.
   void addInitialization(char robot, TypedValues initialization);
+
+  /// @brief Add information for the potential outliers of the dataset
+  void addPotentialOutlierFactors(char robot, std::set<FactorId> potential_outlier_factors);
+
+  /// @brief Add information on the true inliers of the dataset
+  void addOutlierFactors(char robot, std::set<FactorId> outlier_factors);
 
   /// @brief Compiles a dataset from all the added entries
   Dataset build();

--- a/include/jrl/Metrics.h
+++ b/include/jrl/Metrics.h
@@ -15,6 +15,14 @@
 
 namespace jrl {
 
+namespace metrics {
+/// @brief Type helper for Pose Errors. Stored as [Translation, Rotation]
+typedef std::pair<double, double> PoseError;
+
+/// @brief Type helper for Precision Recall. Stored as [Precision, Recall]
+typedef std::pair<double, double> PrecisionRecall;
+}  // namespace metrics
+
 /** @brief SImple Structure for containing a summary metrics
  *
  **/
@@ -28,15 +36,20 @@ struct MetricSummary {
   std::string method_name;
 
   /// @brief The individual ATE for each robot with format: (ATE Translation, ATE Rotation)
-  boost::optional<std::map<char, std::pair<double, double>>> robot_ate{boost::none};
+  boost::optional<std::map<char, metrics::PoseError>> robot_ate{boost::none};
   /// @brief The total ate (sum of robot_ate's) with format: (ATE Translation, ATE Rotation)
-  boost::optional<std::pair<double, double>> total_ate{boost::none};
+  boost::optional<metrics::PoseError> total_ate{boost::none};
 
-  /// @brief The total SVE (sum of robot_sve's)
-  boost::optional<std::pair<double, double>> sve{boost::none};
+  /// @brief The total Shared Variable Error (sum of robot_sve's)
+  boost::optional<metrics::PoseError> sve{boost::none};
 
   /// @brief The Mean Residual
   boost::optional<double> mean_residual{boost::none};
+
+  /// @brief The individual precision and recall for each robot
+  boost::optional<std::map<char, metrics::PrecisionRecall>> robot_precision_recall{boost::none};
+  /// @brief The total precision and recall
+  boost::optional<metrics::PrecisionRecall> precision_recall{boost::none};
 };
 
 namespace metrics {
@@ -48,11 +61,11 @@ namespace internal {
  * Note: For any linear object, the translation is itself
  */
 template <class T>
-inline std::pair<double, double> squaredPoseError(T est, T ref);
+inline PoseError squaredPoseError(T est, T ref);
 template <>
-inline std::pair<double, double> squaredPoseError<gtsam::Pose3>(gtsam::Pose3 est, gtsam::Pose3 ref);
+inline PoseError squaredPoseError<gtsam::Pose3>(gtsam::Pose3 est, gtsam::Pose3 ref);
 template <>
-inline std::pair<double, double> squaredPoseError<gtsam::Pose2>(gtsam::Pose2 est, gtsam::Pose2 ref);
+inline PoseError squaredPoseError<gtsam::Pose2>(gtsam::Pose2 est, gtsam::Pose2 ref);
 }  // namespace internal
 
 /** @brief Computes the ATE for the specified robot.
@@ -66,9 +79,8 @@ inline std::pair<double, double> squaredPoseError<gtsam::Pose2>(gtsam::Pose2 est
  * @returns Pair containing (ATE Translation, ATE Rotation) or boost::none if the dataset does not contain ground truth
  */
 template <class POSE_TYPE>
-inline boost::optional<std::pair<double, double>> computeATE(char rid, Dataset dataset, Results results,
-                                                             bool align = true, bool align_with_scale = false,
-                                                             bool allow_partial_results = false);
+inline boost::optional<PoseError> computeATE(char rid, Dataset dataset, Results results, bool align = true,
+                                             bool align_with_scale = false, bool allow_partial_results = false);
 
 /** @brief Computes the SVE for the dataset
  * SVE is defined as the mean error between all combination of shared variable estimates
@@ -77,13 +89,13 @@ inline boost::optional<std::pair<double, double>> computeATE(char rid, Dataset d
  * @returns The SVE
  */
 template <class POSE_TYPE>
-inline std::pair<double, double> computeSVE(Results results);
+inline PoseError computeSVE(Results results);
 
 /** @brief Computes the mean residual of of the joint solution.
  * Because each robot can vary in their estimate of shared variables. We compute a "Mean Residual"
  * To compute the "Mean Residual", for each factor we compute the residual for each possible combination of variable
  * estimates. When all robots agree perfectly, this would match the residual without evaluating all combinations.
- * @param dataset: The dataset
+ * @param dataset: The dataset 
  * @param results: The estimation results
  * @param step_idx: The number of entries from which we will compute the residual (used if we only have partial results)
  * if nullopt we use all entries
@@ -92,12 +104,28 @@ inline std::pair<double, double> computeSVE(Results results);
 inline double computeMeanResidual(Dataset dataset, Results results,
                                   std::optional<std::map<char, std::optional<size_t>>> step_idx = std::nullopt);
 
+/** @brief Computes Precision and Recall statistics for the given solution
+ * Precision and recall are computed on measurement classifications (inlier vs. outlier) using the set of potential
+ * outliers / true outliers marked in the dataset, along with the set of measurements rejected as outliers in the
+ * solution.
+ * NOTE: Inlier is considered the POSITIVE class for metrics despite results marking outliers
+ * NOTE: If precision or recall cannot be computed this function reports -1
+ * @param dataset: The dataset containing inlier factor information
+ * @param results: The estimation results
+ * @param step_idx: The number of entries from which we will compute the residual (used if we only have partial results)
+ * if nullopt we use all entries
+ * @returns The overall precision and recall, and the per-robot precision and recall
+ */
+std::pair<PrecisionRecall, std::map<char, PrecisionRecall>> computePrecisionRecall(
+    Dataset dataset, Results results, std::optional<std::map<char, std::optional<size_t>>> step_idx = std::nullopt);
+
 /** @brief Computes all metrics possible for the given datasets.
  *  Conditions to compute different metrics
  *  - ATE: dataset must contain groundtruth
  *  - SVE: dataset must be multi-robot
  *  - Mean Residual: always computable
- * Note: If step_idx is provided it is provided to computeMeanResidual, and computeATE is set to allow partial results
+ * Note: If step_idx is provided it is provided to computeMeanResidual, and computeATE is set to allow partial
+ * results
  */
 template <class POSE_TYPE>
 inline MetricSummary computeMetricSummary(Dataset dataset, Results results, bool align = true,

--- a/include/jrl/Metrics.h
+++ b/include/jrl/Metrics.h
@@ -76,11 +76,14 @@ inline PoseError squaredPoseError<gtsam::Pose2>(gtsam::Pose2 est, gtsam::Pose2 r
  * @param results: The estimation results to be compared with the groundtruth
  * @param align_with_scale: If true aligns scale while preforming Umeyama alignment
  * @param allow_partial_results: If true we compute ATE for only the poses in results
+ * @param include_shared_variables: If true we compute ATE including variables from other robots that a robot has
+ * observed.
  * @returns Pair containing (ATE Translation, ATE Rotation) or boost::none if the dataset does not contain ground truth
  */
 template <class POSE_TYPE>
 inline boost::optional<PoseError> computeATE(char rid, Dataset dataset, Results results, bool align = true,
-                                             bool align_with_scale = false, bool allow_partial_results = false);
+                                             bool align_with_scale = false, bool allow_partial_results = false,
+                                             bool include_shared_variables = true);
 
 /** @brief Computes the SVE for the dataset
  * SVE is defined as the mean error between all combination of shared variable estimates
@@ -95,7 +98,7 @@ inline PoseError computeSVE(Results results);
  * Because each robot can vary in their estimate of shared variables. We compute a "Mean Residual"
  * To compute the "Mean Residual", for each factor we compute the residual for each possible combination of variable
  * estimates. When all robots agree perfectly, this would match the residual without evaluating all combinations.
- * @param dataset: The dataset 
+ * @param dataset: The dataset
  * @param results: The estimation results
  * @param step_idx: The number of entries from which we will compute the residual (used if we only have partial results)
  * if nullopt we use all entries
@@ -128,8 +131,8 @@ std::pair<PrecisionRecall, std::map<char, PrecisionRecall>> computePrecisionReca
  * results
  */
 template <class POSE_TYPE>
-inline MetricSummary computeMetricSummary(Dataset dataset, Results results, bool align = true,
-                                          bool align_with_scale = false,
+inline MetricSummary computeMetricSummary(Dataset dataset, Results results, bool ate_align = true,
+                                          bool ate_align_with_scale = false, bool ate_include_shared_variables = true,
                                           std::optional<std::map<char, std::optional<size_t>>> step_idx = std::nullopt);
 
 }  // namespace metrics

--- a/include/jrl/Metrics.h
+++ b/include/jrl/Metrics.h
@@ -39,6 +39,8 @@ struct MetricSummary {
   boost::optional<std::map<char, metrics::PoseError>> robot_ate{boost::none};
   /// @brief The total ate (sum of robot_ate's) with format: (ATE Translation, ATE Rotation)
   boost::optional<metrics::PoseError> total_ate{boost::none};
+  /// @brief The joint ate after preforming a joint Uymeuama alignment with format: (ATE Translation, ATE Rotation)
+  boost::optional<metrics::PoseError> joint_aligned_ate{boost::none};
 
   /// @brief The total Shared Variable Error (sum of robot_sve's)
   boost::optional<metrics::PoseError> sve{boost::none};
@@ -69,7 +71,7 @@ inline PoseError squaredPoseError<gtsam::Pose2>(gtsam::Pose2 est, gtsam::Pose2 r
 }  // namespace internal
 
 /** @brief Computes the ATE for the specified robot.
- * This involves aligning the estiamted and reference trajectories with Umeyama alignment,
+ * This involves aligning the estimated and reference trajectories with Umeyama alignment,
  * then comparing each pose to retrieve a translation and rotation error.
  * @param rid: The robot id of the robot for which to compute ATE
  * @param dataset: The dataset containing groundtruth
@@ -84,6 +86,20 @@ template <class POSE_TYPE>
 inline boost::optional<PoseError> computeATE(char rid, Dataset dataset, Results results, bool align = true,
                                              bool align_with_scale = false, bool allow_partial_results = false,
                                              bool include_shared_variables = true);
+
+/** @brief Computes the Joint Aligned ATE for all robots.
+ * This involves aligning the joint estimated and  joint reference trajectories with Umeyama alignment,
+ * then comparing each pose to retrieve a translation and rotation error.
+ * @param dataset: The dataset containing groundtruth
+ * @param results: The estimation results to be compared with the groundtruth
+ * @param align_with_scale: If true aligns scale while preforming Umeyama alignment
+ * @param allow_partial_results: If true we compute ATE for only the poses in results
+ * @returns Pair containing (ATE Translation, ATE Rotation) or boost::none if the dataset does not contain ground truth
+ */
+template <class POSE_TYPE>
+inline boost::optional<PoseError> computeJointAlignedATE(Dataset dataset, Results results,
+                                                         bool align_with_scale = false,
+                                                         bool allow_partial_results = false);
 
 /** @brief Computes the SVE for the dataset
  * SVE is defined as the mean error between all combination of shared variable estimates

--- a/include/jrl/Results.h
+++ b/include/jrl/Results.h
@@ -25,11 +25,17 @@ struct Results {
   /// appearing multiple times MAY be different.
   std::map<char, TypedValues> robot_solutions;
 
+  /// @brief The set of measurements rejected as outliers and not used to compute the solution.
+  /// Factors are referred to by their index in their owner robot's factor graph.
+  /// Note: Factors can only be rejected if they are declared potential outliers in the dataset.
+  boost::optional<std::map<char, std::set<FactorId>>> robot_outliers;
+
   /** @brief Constructs a results with values
    * @param dataset_json: The json object for the full dataset file.
    */
   Results(std::string dataset_name, std::string method_name, std::vector<char> robots,
-          std::map<char, TypedValues> solutions);
+          std::map<char, TypedValues> solutions,
+          boost::optional<std::map<char, std::set<FactorId>>> robot_outliers = boost::none);
 
   /** @brief Constructs an empty results
    * @param dataset_json: The json object for the full dataset file.

--- a/include/jrl/Types.h
+++ b/include/jrl/Types.h
@@ -29,21 +29,13 @@ struct Entry {
   std::vector<std::string> measurement_types;
   /// @brief The measurements taken by the robot at this time (stamp)
   gtsam::NonlinearFactorGraph measurements;
-  /// @brief Indicates all measurements that may be outliers, and their groundtruth outlier status
-  /// TODO (dan) The Ground truth (statuses) should really be in datasets as a separate optional components to support
-  /// datasets where the true statuses is unknown
-  std::map<gtsam::FactorIndex, bool> potential_outlier_statuses;
 
   /// @brief Function that takes in a type and a factor and returns true if the factor should be kept
   typedef std::function<bool(const std::string&, const gtsam::NonlinearFactor::shared_ptr&)> FilterPredicate;
 
   /// @brief Explicit constructor for an Entry
-  Entry(uint64_t stamp, std::vector<std::string> measurement_types, gtsam::NonlinearFactorGraph measurements,
-        std::map<gtsam::FactorIndex, bool> potential_outlier_statuses = {})
-      : stamp(stamp),
-        measurement_types(measurement_types),
-        measurements(measurements),
-        potential_outlier_statuses(potential_outlier_statuses) {}
+  Entry(uint64_t stamp, std::vector<std::string> measurement_types, gtsam::NonlinearFactorGraph measurements)
+      : stamp(stamp), measurement_types(measurement_types), measurements(measurements) {}
 
   /// @brief Helper to make predicate for filtering based on types
   /// @param types List of jrl tags to keep
@@ -60,5 +52,11 @@ struct Entry {
   /// @return New Entry with only the measurements that satisfy the predicate
   Entry filtered(FilterPredicate predicate) const;
 };
+
+/** @brief A unique identifier for a factor in a dataset. [Entry Idx, Measurement Idx]
+ * Each factor can be uniquely identified by its entry index, and the index that the
+ * factor appears in that entry which we refer to as its Measurement Index.
+ */
+typedef std::pair<size_t, gtsam::FactorIndex> FactorId;
 
 }  // namespace jrl

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -242,17 +242,17 @@ PYBIND11_MODULE(jrl_python, m) {
 
   /**********************************************************************************************************************/
   m.def("computeMetricSummaryPoint2", &metrics::computeMetricSummary<gtsam::Point2>, py::return_value_policy::copy,
-        py::arg("dataset"), py::arg("results"), py::arg("align") = true, py::arg("align_with_scale") = false,
-        py::arg("step_idx") = std::nullopt);
+        py::arg("dataset"), py::arg("results"), py::arg("ate_align") = true, py::arg("ate_align_with_scale") = false,
+        py::arg("ate_include_shared_variables") = true, py::arg("step_idx") = std::nullopt);
   m.def("computeMetricSummaryPoint3", &metrics::computeMetricSummary<gtsam::Point3>, py::return_value_policy::copy,
-        py::arg("dataset"), py::arg("results"), py::arg("align") = true, py::arg("align_with_scale") = false,
-        py::arg("step_idx") = std::nullopt);
+        py::arg("dataset"), py::arg("results"), py::arg("ate_align") = true, py::arg("ate_align_with_scale") = false,
+        py::arg("ate_include_shared_variables") = true, py::arg("step_idx") = std::nullopt);
   m.def("computeMetricSummaryPose2", &metrics::computeMetricSummary<gtsam::Pose2>, py::return_value_policy::copy,
-        py::arg("dataset"), py::arg("results"), py::arg("align") = true, py::arg("align_with_scale") = false,
-        py::arg("step_idx") = std::nullopt);
+        py::arg("dataset"), py::arg("results"), py::arg("ate_align") = true, py::arg("ate_align_with_scale") = false,
+        py::arg("ate_include_shared_variables") = true, py::arg("step_idx") = std::nullopt);
   m.def("computeMetricSummaryPose3", &metrics::computeMetricSummary<gtsam::Pose3>, py::return_value_policy::copy,
-        py::arg("dataset"), py::arg("results"), py::arg("align") = true, py::arg("align_with_scale") = false,
-        py::arg("step_idx") = std::nullopt);
+        py::arg("dataset"), py::arg("results"), py::arg("ate_align") = true, py::arg("ate_align_with_scale") = false,
+        py::arg("ate_include_shared_variables") = true, py::arg("step_idx") = std::nullopt);
 
   /**********************************************************************************************************************/
   m.def("computeMeanResidual", &metrics::computeMeanResidual, py::return_value_policy::copy, py::arg("dataset"),
@@ -267,16 +267,16 @@ PYBIND11_MODULE(jrl_python, m) {
   /**********************************************************************************************************************/
   m.def("computeATEPoint2", &metrics::computeATE<gtsam::Point2>, py::return_value_policy::copy, py::arg("rid"),
         py::arg("dataset"), py::arg("results"), py::arg("align") = true, py::arg("align_with_scale") = false,
-        py::arg("allow_partial_results") = false);
+        py::arg("allow_partial_results") = false, py::arg("include_shared_variables") = false);
   m.def("computeATEPoint3", &metrics::computeATE<gtsam::Point3>, py::return_value_policy::copy, py::arg("rid"),
         py::arg("dataset"), py::arg("results"), py::arg("align") = true, py::arg("align_with_scale") = false,
-        py::arg("allow_partial_results") = false);
+        py::arg("allow_partial_results") = false, py::arg("include_shared_variables") = false);
   m.def("computeATEPose2", &metrics::computeATE<gtsam::Pose2>, py::return_value_policy::copy, py::arg("rid"),
         py::arg("dataset"), py::arg("results"), py::arg("align") = true, py::arg("align_with_scale") = false,
-        py::arg("allow_partial_results") = false);
+        py::arg("allow_partial_results") = false, py::arg("include_shared_variables") = false);
   m.def("computeATEPose3", &metrics::computeATE<gtsam::Pose3>, py::return_value_policy::copy, py::arg("rid"),
         py::arg("dataset"), py::arg("results"), py::arg("align") = true, py::arg("align_with_scale") = false,
-        py::arg("allow_partial_results") = false);
+        py::arg("allow_partial_results") = false, py::arg("include_shared_variables") = false);
 
   /**
    * #### ##    ## #### ######## ####    ###    ##       #### ########    ###    ######## ####  #######  ##    ##

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -161,6 +161,8 @@ PYBIND11_MODULE(jrl_python, m) {
            py::arg("measurement_types"), py::arg("initialization") = py::none(), py::arg("groundtruth") = py::none())
       .def("addGroundTruth", &DatasetBuilder::addGroundTruth, py::arg("robot"), py::arg("groundtruth"))
       .def("addInitialization", &DatasetBuilder::addInitialization, py::arg("robot"), py::arg("initialization"))
+      .def("setPotentialOutlierFactors", &DatasetBuilder::setPotentialOutlierFactors, py::arg("robot"), py::arg("potential_outlier_factors"))
+      .def("setOutlierFactors", &DatasetBuilder::setOutlierFactors, py::arg("robot"), py::arg("outlier_factors"))
       .def("build", &DatasetBuilder::build);
 
   /**

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -60,25 +60,21 @@ PYBIND11_MODULE(jrl_python, m) {
    */
   /**********************************************************************************************************************/
   py::class_<Entry>(m, "Entry")
-      .def(py::init<uint64_t &, std::vector<std::string> &, gtsam::NonlinearFactorGraph &,
-                    std::map<gtsam::FactorIndex, bool> &>(),
-           py::arg("stamp"), py::arg("measurement_types"), py::arg("measurements"),
-           py::arg("potential_outlier_statuses") = std::map<gtsam::FactorIndex, bool>())
+      .def(py::init<uint64_t &, std::vector<std::string> &, gtsam::NonlinearFactorGraph &>(), py::arg("stamp"),
+           py::arg("measurement_types"), py::arg("measurements"))
       .def_readwrite("stamp", &Entry::stamp)
       .def_readwrite("measurement_types", &Entry::measurement_types)
       .def_readwrite("measurements", &Entry::measurements)
-      .def_readwrite("potential_outlier_statuses", &Entry::potential_outlier_statuses)
       .def("filtered", &Entry::filtered)
       .def_static("KeepTypes", &Entry::KeepTypes)
       .def_static("RemoveTypes", &Entry::RemoveTypes)
       .def(py::pickle(
           [](const Entry &entry) {  // __getstate__
-            return py::make_tuple(entry.stamp, entry.measurement_types, entry.measurements,
-                                  entry.potential_outlier_statuses);
+            return py::make_tuple(entry.stamp, entry.measurement_types, entry.measurements);
           },
           [](py::tuple tup) {  // __setstate__
             Entry entry(tup[0].cast<uint64_t>(), tup[1].cast<std::vector<std::string>>(),
-                        tup[2].cast<gtsam::NonlinearFactorGraph>(), tup[3].cast<std::map<gtsam::FactorIndex, bool>>());
+                        tup[2].cast<gtsam::NonlinearFactorGraph>());
             return entry;
           }));
 
@@ -98,45 +94,63 @@ PYBIND11_MODULE(jrl_python, m) {
 
   /**********************************************************************************************************************/
   py::class_<Dataset>(m, "Dataset")
-      .def(py::init<const std::string &, std::vector<char> &, std::map<char, std::vector<Entry>>,
-                    boost::optional<std::map<char, TypedValues>> &, boost::optional<std::map<char, TypedValues>> &>())
+      .def(py::init<const std::string &, std::vector<char> &, std::map<char, std::vector<Entry>> &,
+                    boost::optional<std::map<char, TypedValues>> &, boost::optional<std::map<char, TypedValues>> &,
+                    boost::optional<std::map<char, std::set<FactorId>>> &,
+                    boost::optional<std::map<char, std::set<FactorId>>> &>())
       .def("name", &Dataset::name)
       .def("robots", &Dataset::robots)
+      .def("measurements", &Dataset::measurements)
+      .def("factorGraph", &Dataset::factorGraph)
       .def("groundTruth", &Dataset::groundTruth)
       .def("groundTruthWithTypes", &Dataset::groundTruthWithTypes)
       .def("containsGroundTruth", &Dataset::containsGroundTruth)
       .def("initialization", &Dataset::initialization)
       .def("initializationWithTypes", &Dataset::initializationWithTypes)
       .def("containsInitialization", &Dataset::containsInitialization)
-      .def("measurements", &Dataset::measurements)
-      .def("factorGraph", &Dataset::factorGraph)
+      .def("potentialOutlierFactors", &Dataset::potentialOutlierFactors)
+      .def("containsPotentialOutlierFactors", &Dataset::containsPotentialOutlierFactors)
+      .def("outlierFactors", &Dataset::outlierFactors)
+      .def("containsOutlierFactors", &Dataset::containsOutlierFactors)
       .def(py::pickle(
           [](const Dataset &dataset) {  // __getstate__
             std::map<char, std::vector<Entry>> measurements;
             boost::optional<std::map<char, TypedValues>> ground_truth = boost::none;
             boost::optional<std::map<char, TypedValues>> initialization = boost::none;
+            boost::optional<std::map<char, std::set<FactorId>>> potential_outlier_factors = boost::none;
+            boost::optional<std::map<char, std::set<FactorId>>> outlier_factors = boost::none;
 
             if (dataset.containsGroundTruth()) {
               ground_truth = std::map<char, TypedValues>();
             }
-
             if (dataset.containsInitialization()) {
               initialization = std::map<char, TypedValues>();
+            }
+            if (dataset.containsPotentialOutlierFactors()) {
+              potential_outlier_factors = std::map<char, std::set<FactorId>>();
+            }
+            if (dataset.containsOutlierFactors()) {
+              outlier_factors = std::map<char, std::set<FactorId>>();
             }
 
             for (auto &rid : dataset.robots()) {
               measurements[rid] = dataset.measurements(rid);
               if (ground_truth) (*ground_truth)[rid] = dataset.groundTruthWithTypes(rid);
               if (initialization) (*initialization)[rid] = dataset.initializationWithTypes(rid);
+              if (potential_outlier_factors) (*potential_outlier_factors)[rid] = dataset.potentialOutlierFactors(rid);
+              if (outlier_factors) (*outlier_factors)[rid] = dataset.outlierFactors(rid);
             }
 
-            return py::make_tuple(dataset.name(), dataset.robots(), measurements, ground_truth, initialization);
+            return py::make_tuple(dataset.name(), dataset.robots(), measurements, ground_truth, initialization,
+                                  potential_outlier_factors, outlier_factors);
           },
           [](py::tuple tup) {  // __setstate__
             Dataset dataset(tup[0].cast<std::string>(), tup[1].cast<std::vector<char>>(),
                             tup[2].cast<std::map<char, std::vector<Entry>>>(),
                             tup[3].cast<boost::optional<std::map<char, TypedValues>>>(),
-                            tup[4].cast<boost::optional<std::map<char, TypedValues>>>());
+                            tup[4].cast<boost::optional<std::map<char, TypedValues>>>(),
+                            tup[5].cast<boost::optional<std::map<char, std::set<FactorId>>>>(),
+                            tup[6].cast<boost::optional<std::map<char, std::set<FactorId>>>>());
             return dataset;
           }));
 
@@ -144,8 +158,7 @@ PYBIND11_MODULE(jrl_python, m) {
   py::class_<DatasetBuilder>(m, "DatasetBuilder")
       .def(py::init<const std::string &, std::vector<char> &>())
       .def("addEntry", &DatasetBuilder::addEntry, py::arg("robot"), py::arg("stamp"), py::arg("measurements"),
-           py::arg("measurement_types"), py::arg("potential_outlier_statuses") = std::map<gtsam::FactorIndex, bool>(),
-           py::arg("initialization") = py::none(), py::arg("groundtruth") = py::none())
+           py::arg("measurement_types"), py::arg("initialization") = py::none(), py::arg("groundtruth") = py::none())
       .def("addGroundTruth", &DatasetBuilder::addGroundTruth, py::arg("robot"), py::arg("groundtruth"))
       .def("addInitialization", &DatasetBuilder::addInitialization, py::arg("robot"), py::arg("initialization"))
       .def("build", &DatasetBuilder::build);
@@ -167,13 +180,16 @@ PYBIND11_MODULE(jrl_python, m) {
       .def_readwrite("method_name", &Results::method_name)
       .def_readwrite("robots", &Results::robots)
       .def_readwrite("robot_solutions", &Results::robot_solutions)
+      .def_readwrite("robot_outliers", &Results::robot_outliers)
       .def(py::pickle(
           [](const Results &results) {  // __getstate__
-            return py::make_tuple(results.dataset_name, results.method_name, results.robots, results.robot_solutions);
+            return py::make_tuple(results.dataset_name, results.method_name, results.robots, results.robot_solutions,
+                                  results.robot_outliers);
           },
           [](py::tuple tup) {  // __setstate__
             Results result(tup[0].cast<std::string>(), tup[1].cast<std::string>(), tup[2].cast<std::vector<char>>(),
-                           tup[3].cast<std::map<char, TypedValues>>());
+                           tup[3].cast<std::map<char, TypedValues>>(),
+                           tup[4].cast<boost::optional<std::map<char, std::set<FactorId>>>>());
             return result;
           }));
 
@@ -220,7 +236,9 @@ PYBIND11_MODULE(jrl_python, m) {
       .def_readwrite("robot_ate", &MetricSummary::robot_ate)
       .def_readwrite("total_ate", &MetricSummary::total_ate)
       .def_readwrite("sve", &MetricSummary::sve)
-      .def_readwrite("mean_residual", &MetricSummary::mean_residual);
+      .def_readwrite("mean_residual", &MetricSummary::mean_residual)
+      .def_readwrite("robot_precision_recall", &MetricSummary::robot_precision_recall)
+      .def_readwrite("precision_recall", &MetricSummary::precision_recall);
 
   /**********************************************************************************************************************/
   m.def("computeMetricSummaryPoint2", &metrics::computeMetricSummary<gtsam::Point2>, py::return_value_policy::copy,

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -235,6 +235,7 @@ PYBIND11_MODULE(jrl_python, m) {
       .def_readwrite("method_name", &MetricSummary::method_name)
       .def_readwrite("robot_ate", &MetricSummary::robot_ate)
       .def_readwrite("total_ate", &MetricSummary::total_ate)
+      .def_readwrite("joint_aligned_ate", &MetricSummary::joint_aligned_ate)
       .def_readwrite("sve", &MetricSummary::sve)
       .def_readwrite("mean_residual", &MetricSummary::mean_residual)
       .def_readwrite("robot_precision_recall", &MetricSummary::robot_precision_recall)
@@ -288,4 +289,18 @@ PYBIND11_MODULE(jrl_python, m) {
    * #### ##    ## ####    ##    #### ##     ## ######## #### ######## ##     ##    ##    ####  #######  ##    ##
    */
   py::class_<Initializer>(m, "Initializer").def(py::init<>()).def("initialization", &Initializer::initialization);
+
+  /**
+   *    ###    ##       ####  ######   ##    ## ##     ## ######## ##    ## ########
+   *   ## ##   ##        ##  ##    ##  ###   ## ###   ### ##       ###   ##    ##
+   *  ##   ##  ##        ##  ##        ####  ## #### #### ##       ####  ##    ##
+   * ##     ## ##        ##  ##   #### ## ## ## ## ### ## ######   ## ## ##    ##
+   * ######### ##        ##  ##    ##  ##  #### ##     ## ##       ##  ####    ##
+   * ##     ## ##        ##  ##    ##  ##   ### ##     ## ##       ##   ###    ##
+   * ##     ## ######## ####  ######   ##    ## ##     ## ######## ##    ##    ##
+   */
+  m.def("alignPose2", &alignment::align<gtsam::Pose2>, py::return_value_policy::copy,
+        py::arg("estimate_trajectory"), py::arg("reference_trajectory"), py::arg("align_with_scale") = false);
+  m.def("alignPose3", &alignment::align<gtsam::Pose3>, py::return_value_policy::copy,
+        py::arg("estimate_trajectory"), py::arg("reference_trajectory"), py::arg("align_with_scale") = false);
 }

--- a/src/Dataset.cpp
+++ b/src/Dataset.cpp
@@ -6,12 +6,16 @@ namespace jrl {
 /**********************************************************************************************************************/
 Dataset::Dataset(const std::string name, std::vector<char> robots, std::map<char, std::vector<Entry>> measurements,
                  boost::optional<std::map<char, TypedValues>> ground_truth,
-                 boost::optional<std::map<char, TypedValues>> initial_estimates)
+                 boost::optional<std::map<char, TypedValues>> initial_estimates,
+                 boost::optional<std::map<char, std::set<FactorId>>> potential_outlier_factors,
+                 boost::optional<std::map<char, std::set<FactorId>>> outlier_factors)
     : name_(name),
       robots_(robots),
       measurements_(measurements),
       ground_truth_(ground_truth),
-      initial_estimates_(initial_estimates) {
+      initial_estimates_(initial_estimates),
+      potential_outlier_factors_(potential_outlier_factors),
+      outlier_factors_(outlier_factors) {
   // Construct the factor graphs for each robot from the temporally ordered measurements
   for (const char& rid : robots_) {
     factor_graphs_[rid] = gtsam::NonlinearFactorGraph();
@@ -28,6 +32,16 @@ std::string Dataset::name() const { return name_; }
 
 /**********************************************************************************************************************/
 std::vector<char> Dataset::robots() const { return robots_; }
+
+/**********************************************************************************************************************/
+std::vector<Entry> Dataset::measurements(const boost::optional<char>& robot_id) const {
+  return accessor<std::vector<Entry>>("measurements", measurements_, robot_id);
+}
+
+/**********************************************************************************************************************/
+gtsam::NonlinearFactorGraph Dataset::factorGraph(const boost::optional<char>& robot_id) const {
+  return accessor<gtsam::NonlinearFactorGraph>("factorGraph", factor_graphs_, robot_id);
+}
 
 /**********************************************************************************************************************/
 TypedValues Dataset::groundTruthWithTypes(const boost::optional<char>& robot_id) const {
@@ -47,15 +61,14 @@ gtsam::Values Dataset::initialization(const boost::optional<char>& robot_id) con
 }
 
 /**********************************************************************************************************************/
-std::vector<Entry> Dataset::measurements(const boost::optional<char>& robot_id) const {
-  return accessor<std::vector<Entry>>("measurements", measurements_, robot_id);
+std::set<FactorId> Dataset::potentialOutlierFactors(const boost::optional<char>& robot_id) const {
+  return accessor<std::set<FactorId>>("potentialOutlierFactors", potential_outlier_factors_, robot_id);
 }
 
 /**********************************************************************************************************************/
-gtsam::NonlinearFactorGraph Dataset::factorGraph(const boost::optional<char>& robot_id) const {
-  return accessor<gtsam::NonlinearFactorGraph>("factorGraph", factor_graphs_, robot_id);
+std::set<FactorId> Dataset::outlierFactors(const boost::optional<char>& robot_id) const {
+  return accessor<std::set<FactorId>>("outlierFactors", outlier_factors_, robot_id);
 }
-
 /**********************************************************************************************************************/
 std::set<std::string> Dataset::measurementTypes(const boost::optional<char>& robot_id) const {
   return accessor<std::set<std::string>>("measurementTypes", measurement_types_, robot_id);

--- a/src/DatasetBuilder.cpp
+++ b/src/DatasetBuilder.cpp
@@ -18,7 +18,7 @@ void DatasetBuilder::addEntry(char robot, uint64_t stamp, gtsam::NonlinearFactor
                               std::vector<std::string> measurement_types,
                               const boost::optional<TypedValues> initialization,
                               const boost::optional<TypedValues> groundtruth) {
-  measurements_[robot].push_back(Entry(stamp, measurement_types, measurements));
+  measurements_[robot].emplace_back(stamp, measurement_types, measurements);
   if (initialization) {
     addInitialization(robot, *initialization);
   }
@@ -38,11 +38,11 @@ void DatasetBuilder::addInitialization(char robot, TypedValues initialization) {
   initial_estimates_[robot].types.insert(initialization.types.begin(), initialization.types.end());
 }
 
-void DatasetBuilder::addPotentialOutlierFactors(char robot, std::set<FactorId> potential_outlier_factors) {
+void DatasetBuilder::setPotentialOutlierFactors(char robot, std::set<FactorId> potential_outlier_factors) {
   potential_outlier_factors_[robot] = potential_outlier_factors;
 }
 
-void DatasetBuilder::addOutlierFactors(char robot, std::set<FactorId> outlier_factors) {
+void DatasetBuilder::setOutlierFactors(char robot, std::set<FactorId> outlier_factors) {
   outlier_factors_[robot] = outlier_factors;
 }
 

--- a/src/DatasetBuilder.cpp
+++ b/src/DatasetBuilder.cpp
@@ -7,17 +7,18 @@ namespace jrl {
 DatasetBuilder::DatasetBuilder(const std::string name, std::vector<char> robots) : name_(name), robots_(robots) {
   for (auto& r : robots_) {
     measurements_[r] = std::vector<Entry>();
+    potential_outlier_factors_[r] = std::set<FactorId>();
     initial_estimates_[r] = TypedValues();
     ground_truth_[r] = TypedValues();
+    outlier_factors_[r] = std::set<FactorId>();
   }
 }
 
 void DatasetBuilder::addEntry(char robot, uint64_t stamp, gtsam::NonlinearFactorGraph measurements,
                               std::vector<std::string> measurement_types,
-                              std::map<gtsam::FactorIndex, bool> potential_outlier_statuses,
                               const boost::optional<TypedValues> initialization,
                               const boost::optional<TypedValues> groundtruth) {
-  measurements_[robot].push_back(Entry(stamp, measurement_types, measurements, potential_outlier_statuses));
+  measurements_[robot].push_back(Entry(stamp, measurement_types, measurements));
   if (initialization) {
     addInitialization(robot, *initialization);
   }
@@ -37,12 +38,23 @@ void DatasetBuilder::addInitialization(char robot, TypedValues initialization) {
   initial_estimates_[robot].types.insert(initialization.types.begin(), initialization.types.end());
 }
 
+void DatasetBuilder::addPotentialOutlierFactors(char robot, std::set<FactorId> potential_outlier_factors) {
+  potential_outlier_factors_[robot] = potential_outlier_factors;
+}
+
+void DatasetBuilder::addOutlierFactors(char robot, std::set<FactorId> outlier_factors) {
+  outlier_factors_[robot] = outlier_factors;
+}
+
 Dataset DatasetBuilder::build() {
   boost::optional<std::map<char, TypedValues>> gt = boost::none;
   boost::optional<std::map<char, TypedValues>> init = boost::none;
+  boost::optional<std::map<char, std::set<FactorId>>> potential_outlier_factors = boost::none;
+  boost::optional<std::map<char, std::set<FactorId>>> outlier_factors = boost::none;
   if (ground_truth_[robots_.front()].values.size() > 0) gt = ground_truth_;
   if (initial_estimates_[robots_.front()].values.size() > 0) init = initial_estimates_;
-  return Dataset(name_, robots_, measurements_, gt, init);
+  if (outlier_factors_[robots_.front()].size() > 0) outlier_factors = outlier_factors_;
+  return Dataset(name_, robots_, measurements_, gt, init, potential_outlier_factors, outlier_factors);
 }
 
 }  // namespace jrl

--- a/src/Metrics.cpp
+++ b/src/Metrics.cpp
@@ -1,0 +1,106 @@
+#include "jrl/Metrics.h"
+
+#include "jrl/Alignment.h"
+#include "jrl/Utilities.h"
+
+namespace jrl {
+
+namespace metrics {
+
+/**********************************************************************************************************************/
+std::pair<PrecisionRecall, std::map<char, PrecisionRecall>> computePrecisionRecall(
+    Dataset dataset, Results results, std::optional<std::map<char, std::optional<size_t>>> step_idxes) {
+  // Setup overall counts Positive Class = Inliers
+  double tp = 0;
+  double fp = 0;
+  double tn = 0;
+  double fn = 0;
+
+  // setup container for robot specific stats
+  std::map<char, PrecisionRecall> robot_precision_recall;
+
+  // Iterate over all the robots and compute precision recall + update total counts
+  for (auto& rid : dataset.robots()) {
+    // Setup robot counts
+    double robot_tp = 0;
+    double robot_fp = 0;
+    double robot_tn = 0;
+    double robot_fn = 0;
+
+    // Get all of robot's entries
+    auto entries = dataset.measurements(rid);
+    auto potential_outliers = dataset.potentialOutlierFactors(rid);
+    auto true_outliers = dataset.outlierFactors(rid);
+
+    // Get the index of the last entry to use to compute the stats
+    size_t stop_idx;
+    if (!step_idxes.has_value()) {
+      // No step idxes provided so compute on all entries
+      stop_idx = entries.size();
+    } else if (step_idxes->at(rid).has_value()) {
+      // Step idxes is provided and has a value for this robot
+      stop_idx = *(step_idxes->at(rid));
+    } else {
+      // Step idxes provided but robot has not started
+      stop_idx = 0;
+    }
+
+    // For all relevant entries include in counts
+    for (size_t entry_idx = 0; entry_idx < stop_idx; entry_idx++) {
+      auto entry = entries[entry_idx];
+      size_t num_entry_factors = entry.measurements.nrFactors();
+
+      // For each measurement in this entry
+      for (size_t measure_idx = 0; measure_idx < num_entry_factors; measure_idx++) {
+        FactorId factor_id = std::make_pair(entry_idx, measure_idx);
+        bool potential_outlier = potential_outliers.find(factor_id) != potential_outliers.end();
+        // If the measurement is in the set of potential outliers include it in the computation
+        if (potential_outlier) {
+          bool is_outlier = true_outliers.find(factor_id) != true_outliers.end();
+          bool pred_outlier = (*results.robot_outliers)[rid].find(factor_id) != (*results.robot_outliers)[rid].end();
+
+          // Increment True/False Positive/Negative
+          if (!is_outlier && !pred_outlier) {
+            robot_tp++;
+          } else if (!is_outlier && pred_outlier) {
+            robot_fn++;
+          } else if (is_outlier && !pred_outlier) {
+            robot_fp++;
+          } else if (is_outlier && pred_outlier) {
+            robot_tn++;
+          }
+        }
+
+        // Initialize Precision + Recall with invalid options for case of zero denominator
+        double robot_precision = -1.0;
+        double robot_recall = -1.0;
+
+        // Compute the Precision and Recall for this robot
+        if (robot_tp + robot_fp > 0.0) robot_precision = robot_tp / (robot_tp + robot_fp);
+        if (robot_tp + robot_fn > 0.0) robot_recall = robot_tp / (robot_tp + robot_fn);
+        robot_precision_recall[rid] = std::make_pair(robot_precision, robot_recall);
+      }
+    }
+
+    // Update the global counts
+    tp += robot_tp;
+    fp += robot_fp;
+    tn += robot_tn;
+    fn += robot_fn;
+  }
+
+  // Initialize Precision + Recall with invalid options for case of zero denominator
+  double precision = -1.0;
+  double recall = -1.0;
+
+  // Compute the Precision and Recall for for all robots
+  if (tp + fp > 0.0) precision = tp / (tp + fp);
+  if (tp + fn > 0.0) recall = tp / (tp + fn);
+  auto precision_recall = std::make_pair(precision, recall);
+
+  // Return all results
+  return std::make_pair(precision_recall, robot_precision_recall);
+}
+
+}  // namespace metrics
+}  // namespace jrl

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -199,6 +199,9 @@ MetricSummary Parser::parseMetricSummary(std::string metric_summary_file, bool d
   if (results_json.contains("total_ate")) {
     metric_summary.total_ate = results_json["total_ate"].get<metrics::PoseError>();
   }
+  if (results_json.contains("joint_aligned_ate")) {
+    metric_summary.joint_aligned_ate = results_json["joint_aligned_ate"].get<metrics::PoseError>();
+  }
   if (results_json.contains("sve")) {
     metric_summary.sve = results_json["sve"].get<metrics::PoseError>();
   }

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -5,6 +5,7 @@
 #include <gtsam/slam/PriorFactor.h>
 
 #include <fstream>
+#include <set>
 
 #include "jrl/IOMeasurements.h"
 #include "jrl/IOValues.h"
@@ -79,19 +80,14 @@ std::vector<Entry> Parser::parseMeasurements(const json& measurements_json) cons
     uint64_t stamp = entry_element["stamp"].get<uint64_t>();
     gtsam::NonlinearFactorGraph entry_measurements;
     std::vector<std::string> type_tags;
-    if(entry_element.contains("measurements")) {
+    if (entry_element.contains("measurements")) {
       for (auto& measurement : entry_element["measurements"]) {
         std::string tag = measurement["type"].get<std::string>();
         type_tags.push_back(tag);
         entry_measurements.push_back(measurement_parsers_.at(tag)(measurement));
       }
     }
-    std::map<gtsam::FactorIndex, bool> potential_outlier_statuses;
-    if (entry_element.contains("potential_outlier_statuses")) {
-      potential_outlier_statuses =
-          entry_element["potential_outlier_statuses"].get<std::map<gtsam::FactorIndex, bool>>();
-    }
-    measurements.emplace_back(stamp, type_tags, entry_measurements, potential_outlier_statuses);
+    measurements.emplace_back(stamp, type_tags, entry_measurements);
   }
   return measurements;
 }
@@ -117,6 +113,12 @@ Dataset Parser::parseDataset(std::string dataset_file, bool decompress_from_cbor
   std::string name = dataset_json["name"];
   std::vector<char> robots = dataset_json["robots"].get<std::vector<char>>();
 
+  // Parse Measurements
+  std::map<char, std::vector<Entry>> measurements;
+  for (auto& el : dataset_json["measurements"].items()) {
+    measurements[el.key()[0]] = parseMeasurements(el.value());
+  }
+
   // Parse Ground truth if it exists
   boost::optional<std::map<char, TypedValues>> groundtruth = boost::none;
   if (dataset_json.contains("groundtruth")) {
@@ -135,13 +137,25 @@ Dataset Parser::parseDataset(std::string dataset_file, bool decompress_from_cbor
     }
   }
 
-  // Parse Measurements if it exists
-  std::map<char, std::vector<Entry>> measurements;
-  for (auto& el : dataset_json["measurements"].items()) {
-    measurements[el.key()[0]] = parseMeasurements(el.value());
+  // Parse Potential Outliers
+  boost::optional<std::map<char, std::set<FactorId>>> potential_outlier_factors = boost::none;
+  if (dataset_json.contains("potential_outlier_factors")) {
+    potential_outlier_factors = std::map<char, std::set<FactorId>>();
+    for (auto& el : dataset_json["potential_outlier_factors"].items()) {
+      (*potential_outlier_factors)[el.key()[0]] = el.value().get<std::set<FactorId>>();
+    }
   }
 
-  return Dataset(name, robots, measurements, groundtruth, initialization);
+  // Parse the ground truth inliers if they exist
+  boost::optional<std::map<char, std::set<FactorId>>> outlier_factors = boost::none;
+  if (dataset_json.contains("outlier_factors")) {
+    outlier_factors = std::map<char, std::set<FactorId>>();
+    for (auto& el : dataset_json["outlier_factors"].items()) {
+      (*outlier_factors)[el.key()[0]] = el.value().get<std::set<FactorId>>();
+    }
+  }
+
+  return Dataset(name, robots, measurements, groundtruth, initialization, potential_outlier_factors, outlier_factors);
 }
 
 /**********************************************************************************************************************/
@@ -153,12 +167,22 @@ Results Parser::parseResults(std::string results_file, bool decompress_from_cbor
   std::string method_name = results_json["method_name"];
   std::vector<char> robots = results_json["robots"].get<std::vector<char>>();
 
-  // Parse Ground truth if it exists
+  // Parse the solutions
   std::map<char, TypedValues> solutions;
   for (auto& el : results_json["solutions"].items()) {
     solutions[el.key()[0]] = parseValues(el.value());
   }
-  return Results(dataset_name, method_name, robots, solutions);
+
+  // Parse the marked outliers
+  boost::optional<std::map<char, std::set<FactorId>>> outliers = boost::none;
+  if (results_json.contains("outliers")) {
+    outliers = std::map<char, std::set<FactorId>>();
+    for (auto& el : results_json["outliers"].items()) {
+      (*outliers)[el.key()[0]] = el.value().get<std::set<FactorId>>();
+    }
+  }
+
+  return Results(dataset_name, method_name, robots, solutions, outliers);
 }
 
 /**********************************************************************************************************************/
@@ -170,16 +194,24 @@ MetricSummary Parser::parseMetricSummary(std::string metric_summary_file, bool d
   metric_summary.robots = results_json["robots"].get<std::vector<char>>();
 
   if (results_json.contains("robot_ate")) {
-    metric_summary.robot_ate = results_json["robot_ate"].get<std::map<char, std::pair<double, double>>>();
+    metric_summary.robot_ate = results_json["robot_ate"].get<std::map<char, metrics::PoseError>>();
   }
   if (results_json.contains("total_ate")) {
-    metric_summary.total_ate = results_json["total_ate"].get<std::pair<double, double>>();
+    metric_summary.total_ate = results_json["total_ate"].get<metrics::PoseError>();
   }
   if (results_json.contains("sve")) {
-    metric_summary.sve = results_json["sve"].get<std::pair<double, double>>();
+    metric_summary.sve = results_json["sve"].get<metrics::PoseError>();
   }
   if (results_json.contains("mean_residual")) {
     metric_summary.mean_residual = results_json["mean_residual"].get<double>();
+  }
+
+  if (results_json.contains("robot_precision_recall")) {
+    metric_summary.robot_precision_recall =
+        results_json["robot_precision_recall"].get<std::map<char, metrics::PrecisionRecall>>();
+  }
+  if (results_json.contains("precision_recall")) {
+    metric_summary.precision_recall = results_json["precision_recall"].get<metrics::PrecisionRecall>();
   }
 
   return metric_summary;

--- a/src/Results.cpp
+++ b/src/Results.cpp
@@ -5,8 +5,13 @@
 namespace jrl {
 /**********************************************************************************************************************/
 Results::Results(std::string dataset_name, std::string method_name, std::vector<char> robots,
-                 std::map<char, TypedValues> solutions)
-    : dataset_name(dataset_name), method_name(method_name), robots(robots), robot_solutions(solutions) {}
+                 std::map<char, TypedValues> solutions,
+                 boost::optional<std::map<char, std::set<FactorId>>> robot_outliers)
+    : dataset_name(dataset_name),
+      method_name(method_name),
+      robots(robots),
+      robot_solutions(solutions),
+      robot_outliers(robot_outliers) {}
 
 /**********************************************************************************************************************/
 Results::Results(std::string dataset_name, std::string method_name, std::vector<char> robots)

--- a/src/Types.cpp
+++ b/src/Types.cpp
@@ -20,21 +20,17 @@ Entry::FilterPredicate Entry::RemoveTypes(std::vector<std::string> types) {
 Entry Entry::filtered(Entry::FilterPredicate predicate) const {
   std::vector<std::string> out_measurement_types;
   gtsam::NonlinearFactorGraph out_measurements;
-  std::map<gtsam::FactorIndex, bool> out_potential_outlier_statuses;
   gtsam::FactorIndex curr = 0;
 
   for (uint64_t i = 0; i < measurement_types.size(); ++i) {
     if (predicate(measurement_types[i], measurements[i])) {
       out_measurement_types.push_back(measurement_types[i]);
       out_measurements.push_back(measurements[i]);
-      if (potential_outlier_statuses.find(i) != potential_outlier_statuses.end()) {
-        out_potential_outlier_statuses[curr] = potential_outlier_statuses.at(i);
-      }
       curr += 1;
     }
   }
 
-  return Entry(stamp, out_measurement_types, out_measurements, out_potential_outlier_statuses);
+  return Entry(stamp, out_measurement_types, out_measurements);
 }
 
 }  // namespace jrl

--- a/src/Writer.cpp
+++ b/src/Writer.cpp
@@ -201,6 +201,7 @@ void Writer::writeMetricSummary(MetricSummary metric_summary, std::string output
   output_json["robots"] = metric_summary.robots;
   if (metric_summary.robot_ate) output_json["robot_ate"] = *metric_summary.robot_ate;
   if (metric_summary.total_ate) output_json["total_ate"] = *metric_summary.total_ate;
+  if (metric_summary.joint_aligned_ate) output_json["joint_aligned_ate"] = *metric_summary.joint_aligned_ate;
   if (metric_summary.sve) output_json["sve"] = *metric_summary.sve;
   if (metric_summary.mean_residual) output_json["mean_residual"] = *metric_summary.mean_residual;
   if (metric_summary.robot_precision_recall)

--- a/src/Writer.cpp
+++ b/src/Writer.cpp
@@ -89,9 +89,6 @@ json Writer::serializeMeasurements(std::vector<Entry> entries) const {
       gtsam::NonlinearFactor::shared_ptr factor = entry.measurements.at(i);
       entry_obj["measurements"].push_back(measurement_serializers_.at(measurement_type)(factor));
     }
-    if (!entry.potential_outlier_statuses.empty()) {
-      entry_obj["potential_outlier_statuses"] = entry.potential_outlier_statuses;
-    }
     output.push_back(entry_obj);
   }
   return output;
@@ -118,7 +115,7 @@ void Writer::writeDataset(Dataset dataset, std::string output_file_name, bool co
   output_json["name"] = dataset.name();
   output_json["robots"] = dataset.robots();
 
-  // serialize Measurements
+  // Serialize measurements
   json measurements_json;
   for (auto& robot : dataset.robots()) {
     measurements_json[std::string(1, robot)] = serializeMeasurements(dataset.measurements(robot));
@@ -133,7 +130,6 @@ void Writer::writeDataset(Dataset dataset, std::string output_file_name, bool co
     }
     output_json["groundtruth"] = groundtruth_json;
   }
-
   // Serialize Initialization if it exists
   json initialization_json;
   if (dataset.containsInitialization()) {
@@ -141,6 +137,24 @@ void Writer::writeDataset(Dataset dataset, std::string output_file_name, bool co
       initialization_json[std::string(1, robot)] = serializeValues(dataset.initializationWithTypes(robot));
     }
     output_json["initialization"] = initialization_json;
+  }
+
+  // Serialize potential outliers
+  json potential_outlier_factors_json;
+  if (dataset.containsPotentialOutlierFactors()) {
+    for (auto& robot : dataset.robots()) {
+      potential_outlier_factors_json[std::string(1, robot)] = dataset.potentialOutlierFactors(robot);
+    }
+    output_json["potential_outlier_factors"] = potential_outlier_factors_json;
+  }
+
+  // Serialize Inlier Factors if it exists
+  json outlier_factors_json;
+  if (dataset.containsOutlierFactors()) {
+    for (auto& robot : dataset.robots()) {
+      outlier_factors_json[std::string(1, robot)] = dataset.outlierFactors(robot);
+    }
+    output_json["outlier_factors"] = outlier_factors_json;
   }
 
   // Write the file
@@ -162,6 +176,16 @@ void Writer::writeResults(Results results, std::string output_file_name, bool co
     solution_json[std::string(1, robot)] = serializeValues(results.robot_solutions[robot]);
   }
   output_json["solutions"] = solution_json;
+
+  // Serialize Outliers
+  if (results.robot_outliers) {
+    json outliers_json;
+    for (auto& robot : results.robots) {
+      solution_json[std::string(1, robot)] = (*results.robot_outliers)[robot];
+    }
+    output_json["outliers"] = solution_json;
+  }
+
   // Write the file
   writeJson(output_json, output_file_name, compress_to_cbor);
 }
@@ -179,6 +203,9 @@ void Writer::writeMetricSummary(MetricSummary metric_summary, std::string output
   if (metric_summary.total_ate) output_json["total_ate"] = *metric_summary.total_ate;
   if (metric_summary.sve) output_json["sve"] = *metric_summary.sve;
   if (metric_summary.mean_residual) output_json["mean_residual"] = *metric_summary.mean_residual;
+  if (metric_summary.robot_precision_recall)
+    output_json["robot_precision_recall"] = *metric_summary.robot_precision_recall;
+  if (metric_summary.precision_recall) output_json["precision_recall"] = *metric_summary.precision_recall;
 
   // Write the file
   writeJson(output_json, output_file_name, compress_to_cbor);

--- a/tests/test_Types.cpp
+++ b/tests/test_Types.cpp
@@ -28,8 +28,7 @@ TEST(Types, EntryRemove) {
   graph.push_back(factor_between);
 
   std::vector<std::string> tags{jrl::PriorFactorPose2Tag, jrl::BetweenFactorPose2Tag};
-  std::map<gtsam::FactorIndex, bool> potential_outlier_statuses{{0, false}, {1, true}};
-  jrl::Entry entry = jrl::Entry(0, tags, graph, potential_outlier_statuses);
+  jrl::Entry entry = jrl::Entry(0, tags, graph);
 
   auto pred = jrl::Entry::RemoveTypes({jrl::BetweenFactorPose2Tag});
   jrl::Entry split = entry.filtered(pred);
@@ -38,7 +37,6 @@ TEST(Types, EntryRemove) {
   EXPECT_EQ(1, split.measurement_types.size());
   EXPECT_EQ(jrl::PriorFactorPose2Tag, split.measurement_types[0]);
   EXPECT_TRUE(factor_prior.equals(*split.measurements[0]));
-  EXPECT_FALSE(split.potential_outlier_statuses[0]);
 }
 
 TEST(Types, EntryKeep) {
@@ -53,8 +51,7 @@ TEST(Types, EntryKeep) {
   graph.push_back(factor_between);
 
   std::vector<std::string> tags{jrl::PriorFactorPose2Tag, jrl::BetweenFactorPose2Tag};
-  std::map<gtsam::FactorIndex, bool> potential_outlier_statuses{{0, false}, {1, true}};
-  jrl::Entry entry = jrl::Entry(0, tags, graph, potential_outlier_statuses);
+  jrl::Entry entry = jrl::Entry(0, tags, graph);
 
   auto pred = jrl::Entry::KeepTypes({jrl::BetweenFactorPose2Tag});
   jrl::Entry split = entry.filtered(pred);
@@ -63,5 +60,4 @@ TEST(Types, EntryKeep) {
   EXPECT_EQ(1, split.measurement_types.size());
   EXPECT_EQ(jrl::BetweenFactorPose2Tag, split.measurement_types[0]);
   EXPECT_TRUE(factor_between.equals(*split.measurements[0]));
-  EXPECT_TRUE(split.potential_outlier_statuses[0]);
 }


### PR DESCRIPTION
This PR significantly updates the scheme used for including outlier information in JRL datasets.

Old Scheme:
- Outliers marked in measurement entries via `potential_outlier_statuses`

New Scheme
- Potential outliers marked at top level of dataset as list of `FactorId`
- Outlier Groundtruth marked at top level of dataset as list of `FactorId`


These changes were motivated by a few things
1. Optional Groundtruth - The previous scheme required that users have groundtruth outlier information which may not be feasible for real world datasets. The new scheme separates marking potential outliers and providing their groundtruth outlier status.
2. Metrics - Computing metrics with the old scheme was annoying since you had to traverse through all the measurements to extract info about the outliers.
3. Common References to Factors - The old scheme did not define a way for algorithms to refer individual factors in a clear way (for example to define it as a rejected outlier). The new scheme defines an unambiguous identifier `FactorId` for all measurements via their entry index and measurement index within that entry. This gives a common languages for referring to specific measurements.

Note: These changes are NOT backwards compatible, it will break any datasets that use the old outlier definition scheme. However, I dont think anyone but myself used/created any datasets with the old scheme so this should not be an issue. 

To be clear, these changes ARE backwards compatible with any dataset that does not mark outliers (the old scheme was optional as is the new one).

Finally, this PR adds new outlier based metrics, and does so improvements to options in the metric computation!