### PR TITLE
Enable Ubuntu 22.04 Compatability

### DIFF
--- a/LIBRARY.md
+++ b/LIBRARY.md
@@ -37,7 +37,7 @@ We use `boost::optional` over the c++17 supported `std::optional` as that is wha
 #### Containers
 We use `stl` containers over GTSAM "fast" containers to allow implicit conversion via pybind11's `stl.h`
 
-#### Dependencies (Ubuntu 20.04)
+#### Dependencies (Target Platform = Ubuntu 20.04 or 22.04)
 JRL relies heavily on GTSAM for its geometry, factor, and container types. GTSAM should be installed on the machine or a local build of GTSAM should be linked by setting `GTSAM_DIR` and `GTSAM_INCLUDE_DIR` CMake options. JRL currently targets GTSAM v4.2.0.
 
 Since C++ does not have a native support for parsing JSON we use a 3rd party library for JSON support. We specifically choose [nlohmann-json](https://github.com/nlohmann/json) because of its ease of use, quality design + implementation, and support across platforms.

--- a/include/jrl/Initialization.h
+++ b/include/jrl/Initialization.h
@@ -6,6 +6,8 @@
 #pragma once
 #include <gtsam/geometry/BearingRange.h>
 
+#include <optional>
+
 #include "jrl/Dataset.h"
 #include "jrl/Types.h"
 

--- a/include/jrl/Metrics.h
+++ b/include/jrl/Metrics.h
@@ -8,6 +8,7 @@
 #include <gtsam/inference/Symbol.h>
 #include <gtsam/nonlinear/Values.h>
 
+#include <optional>
 #include <vector>
 
 #include "jrl/Dataset.h"

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -97,7 +97,7 @@ json Parser::parseJson(std::string input_file_name, bool decompress_from_cbor) c
   json parsed_json;
   if (decompress_from_cbor) {
     std::ifstream ifs(input_file_name, std::ios::binary);
-    parsed_json = json::from_cbor(nlohmann::detail::input_adapter{ifs});
+    parsed_json = json::from_cbor(ifs);
   } else {
     std::ifstream ifs(input_file_name);
     parsed_json = json::parse(ifs);


### PR DESCRIPTION
The nlohmann-json and default gcc version shipped with ubuntu 22.04  require a few changes to the includes and to the usage of the json interface. These changes are intended to make jrl compatible with Ubuntu 22.04 by default. These changes are backwards compatible with Ubuntu 20.04.